### PR TITLE
fix: gh CLI path resolution + onboarding identity improvements

### DIFF
--- a/v2/frontend/src/screens/onboarding/OnboardingFlow.tsx
+++ b/v2/frontend/src/screens/onboarding/OnboardingFlow.tsx
@@ -23,6 +23,7 @@ interface OnboardingFlowProps {
 export function OnboardingFlow(props: OnboardingFlowProps) {
   const [phase, setPhase] = createSignal<PhaseId>('awakening');
   const [dissolving, setDissolving] = createSignal(false);
+  const [bootOperator, setBootOperator] = createSignal<string>('');
   const data: Record<string, string> = {};
 
   const completedPhases = () => Math.max(0, phaseOrder.indexOf(phase()) - 1);
@@ -58,14 +59,14 @@ export function OnboardingFlow(props: OnboardingFlowProps) {
       <div class={styles.scanlines} />
 
       <Show when={phase() === 'awakening'}>
-        <BootTerminal onBootComplete={() => advancePhase()} />
+        <BootTerminal onBootComplete={(op) => { setBootOperator(op ?? ''); advancePhase(); }} />
       </Show>
 
       <Show when={isMiddlePhase()}>
         <div class={styles.phaseContainer}>
           <Switch>
             <Match when={phase() === 'identity-bind'}>
-              <IdentityBind onComplete={handlePhaseComplete} />
+              <IdentityBind detectedName={bootOperator()} onComplete={handlePhaseComplete} />
             </Match>
             <Match when={phase() === 'domain-select'}>
               <DomainSelect onComplete={handlePhaseComplete} />

--- a/v2/frontend/src/screens/onboarding/config/types.ts
+++ b/v2/frontend/src/screens/onboarding/config/types.ts
@@ -68,6 +68,7 @@ export interface DetectedAgent {
 export interface BootScanData {
   gitInstalled: boolean;
   gitVersion?: string;
+  operator?: string;
   agents: DetectedAgent[];
 }
 

--- a/v2/frontend/src/screens/onboarding/phases/BootTerminal.tsx
+++ b/v2/frontend/src/screens/onboarding/phases/BootTerminal.tsx
@@ -13,7 +13,7 @@ import { PhantomMark } from '../../../shared/PhantomMark/PhantomMark';
 const App = () => (window as any).go?.['app']?.App;
 
 interface BootTerminalProps {
-  onBootComplete: () => void;
+  onBootComplete: (operator?: string) => void;
 }
 
 interface DisplayLine {
@@ -111,6 +111,7 @@ export function BootTerminal(props: BootTerminalProps) {
 
     let sessionCount = 0;
     let scan: BootScanData | undefined;
+    let detectedOperator: string | undefined;
     try {
       const sessions = await getSessions();
       sessionCount = sessions.length;
@@ -120,9 +121,11 @@ export function BootTerminal(props: BootTerminalProps) {
       if (app?.BootScan) {
         const raw = await app.BootScan();
         if (raw) {
+          detectedOperator = raw.operator || undefined;
           scan = {
             gitInstalled: raw.gitInstalled ?? false,
             gitVersion: raw.gitVersion,
+            operator: detectedOperator,
             agents: raw.agents ?? [],
           };
         }
@@ -138,7 +141,7 @@ export function BootTerminal(props: BootTerminalProps) {
     }
 
     await new Promise<void>((r) => setTimeout(r, 600));
-    if (!cancelled) props.onBootComplete();
+    if (!cancelled) props.onBootComplete(detectedOperator);
   });
 
   onCleanup(() => {

--- a/v2/frontend/src/screens/onboarding/phases/IdentityBind.tsx
+++ b/v2/frontend/src/screens/onboarding/phases/IdentityBind.tsx
@@ -2,7 +2,6 @@
 
 import { createSignal, onMount, onCleanup, Show } from 'solid-js';
 import { TextField } from '@kobalte/core/text-field';
-import { getGitUserName } from '../../../core/bindings';
 import { playSound } from '../../../core/audio/engine';
 import { speakSystem } from '../config/voice';
 import { buttonRecipe } from '../../../styles/recipes.css';
@@ -11,24 +10,21 @@ import { AutoTimer } from '../engine/AutoTimer';
 import * as styles from '../styles/phases.css';
 
 interface IdentityBindProps {
+  detectedName: string;
   onComplete: (data: Record<string, string>) => void;
 }
 
 export function IdentityBind(props: IdentityBindProps) {
-  const [name, setName] = createSignal('');
-  const [detected, setDetected] = createSignal('');
+  const [name, setName] = createSignal(props.detectedName);
   const [paused, setPaused] = createSignal(false);
 
-  onMount(async () => {
+  onMount(() => {
     playSound('whoosh');
-    const speechTimer = setTimeout(() => speakSystem('Identity detected. Locking in.'), 250);
+    const speech = props.detectedName
+      ? 'Identity detected. Locking in.'
+      : 'State your name, Operator.';
+    const speechTimer = setTimeout(() => speakSystem(speech), 250);
     onCleanup(() => clearTimeout(speechTimer));
-
-    const gitName = await getGitUserName();
-    if (gitName) {
-      setDetected(gitName);
-      setName(gitName);
-    }
   });
 
   function handleSubmit() {
@@ -38,7 +34,7 @@ export function IdentityBind(props: IdentityBindProps) {
   }
 
   function handleAutoResolve() {
-    props.onComplete({ operator_name: name().trim() || detected() || '' });
+    props.onComplete({ operator_name: name().trim() || props.detectedName });
   }
 
   function handleInteraction() {
@@ -71,9 +67,9 @@ export function IdentityBind(props: IdentityBindProps) {
           </TextField>
         </div>
 
-        <Show when={detected()}>
+        <Show when={props.detectedName}>
           <div class={`${styles.label} ${styles.labelDetected}`}>
-            Identity detected: {detected()}
+            Identity detected: {props.detectedName}
           </div>
         </Show>
 
@@ -88,12 +84,14 @@ export function IdentityBind(props: IdentityBindProps) {
         </div>
       </div>
 
-      <AutoTimer
-        timeout={10000}
-        onResolve={handleAutoResolve}
-        message="No override detected. Identity locked."
-        paused={paused()}
-      />
+      <Show when={!!props.detectedName}>
+        <AutoTimer
+          timeout={10000}
+          onResolve={handleAutoResolve}
+          message="No override detected. Identity locked."
+          paused={paused()}
+        />
+      </Show>
     </PhasePanel>
   );
 }

--- a/v2/internal/git/github.go
+++ b/v2/internal/git/github.go
@@ -18,7 +18,7 @@ import (
 // IsGhAvailable returns true if the gh CLI is authenticated and available.
 func IsGhAvailable(ctx context.Context) bool {
 	log.Info("git/IsGhAvailable: called")
-	cmd := exec.CommandContext(ctx, "gh", "auth", "status")
+	cmd := exec.CommandContext(ctx, ghBin(), "auth", "status")
 	err := cmd.Run()
 	if err != nil {
 		log.Info("git/IsGhAvailable: gh not available", "err", err)
@@ -112,7 +112,7 @@ func computeCheckSummary(checks []ghCheckRunJSON) (passed, failed, pending int) 
 func GetPrStatus(ctx context.Context, repoPath, branch string) (*PrStatus, error) {
 	log.Info("git/GetPrStatus: called", "repoPath", repoPath, "branch", branch)
 
-	cmd := exec.CommandContext(ctx, "gh", "pr", "view", branch,
+	cmd := exec.CommandContext(ctx, ghBin(), "pr", "view", branch,
 		"--json", "number,title,state,url,headRefName,baseRefName,isDraft,author,createdAt,mergedAt,statusCheckRollup,mergeable,mergeStateStatus,reviewDecision,autoMergeRequest,latestReviews,reviewRequests",
 	)
 	cmd.Dir = repoPath
@@ -228,7 +228,7 @@ func getMergeQueueEntry(ctx context.Context, repoPath string, prNumber int) (sta
 
 	query := `query($owner:String!,$name:String!,$num:Int!){repository(owner:$owner,name:$name){pullRequest(number:$num){mergeQueueEntry{state position estimatedTimeToMerge}}}}`
 
-	cmd := exec.CommandContext(ctx, "gh", "api", "graphql",
+	cmd := exec.CommandContext(ctx, ghBin(), "api", "graphql",
 		"-f", "query="+query,
 		"-F", "owner="+owner,
 		"-F", "name="+name,
@@ -267,7 +267,7 @@ func getMergeQueueEntry(ctx context.Context, repoPath string, prNumber int) (sta
 func ListOpenPrsForBase(ctx context.Context, repoPath, baseBranch string, limit int) ([]PrStatus, error) {
 	log.Info("git/ListOpenPrsForBase: called", "repoPath", repoPath, "base", baseBranch, "limit", limit)
 
-	cmd := exec.CommandContext(ctx, "gh", "pr", "list",
+	cmd := exec.CommandContext(ctx, ghBin(), "pr", "list",
 		"--base", baseBranch,
 		"--state", "open",
 		"--limit", fmt.Sprintf("%d", limit),
@@ -342,7 +342,7 @@ type ghCheckJSON struct {
 func GetCiRuns(ctx context.Context, repoPath, branch string) ([]CiRun, error) {
 	log.Info("git/GetCiRuns: called", "repoPath", repoPath, "branch", branch)
 
-	cmd := exec.CommandContext(ctx, "gh", "pr", "checks", branch,
+	cmd := exec.CommandContext(ctx, ghBin(), "pr", "checks", branch,
 		"--json", "name,state,bucket,link,workflow,description",
 	)
 	cmd.Dir = repoPath
@@ -402,7 +402,7 @@ func GetCheckAnnotations(ctx context.Context, repoPath, branch, checkName string
 	}
 
 	apiPath := fmt.Sprintf("repos/%s/commits/%s/check-runs", ownerRepo, sha)
-	cmd := exec.CommandContext(ctx, "gh", "api", apiPath, "--jq",
+	cmd := exec.CommandContext(ctx, ghBin(), "api", apiPath, "--jq",
 		fmt.Sprintf(".check_runs[] | select(.name == \"%s\") | .id", checkName))
 	cmd.Dir = repoPath
 	var stdout bytes.Buffer
@@ -417,7 +417,7 @@ func GetCheckAnnotations(ctx context.Context, repoPath, branch, checkName string
 	}
 
 	annotationsPath := fmt.Sprintf("repos/%s/check-runs/%s/annotations", ownerRepo, checkRunID)
-	annoCmd := exec.CommandContext(ctx, "gh", "api", annotationsPath)
+	annoCmd := exec.CommandContext(ctx, ghBin(), "api", annotationsPath)
 	annoCmd.Dir = repoPath
 	var annoOut bytes.Buffer
 	annoCmd.Stdout = &annoOut
@@ -456,7 +456,7 @@ func GetFailedSteps(ctx context.Context, repoPath, checkURL string) ([]FailedSte
 	}
 
 	apiPath := fmt.Sprintf("repos/%s/actions/runs/%s/jobs?per_page=100&filter=latest", ownerRepo, runID)
-	cmd := exec.CommandContext(ctx, "gh", "api", apiPath)
+	cmd := exec.CommandContext(ctx, ghBin(), "api", apiPath)
 	cmd.Dir = repoPath
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
@@ -511,7 +511,7 @@ func GetFailedSteps(ctx context.Context, repoPath, checkURL string) ([]FailedSte
 
 func fetchJobErrors(ctx context.Context, repoPath, ownerRepo string, jobID int64) []string {
 	logsPath := fmt.Sprintf("repos/%s/actions/jobs/%d/logs", ownerRepo, jobID)
-	cmd := exec.CommandContext(ctx, "gh", "api", logsPath)
+	cmd := exec.CommandContext(ctx, ghBin(), "api", logsPath)
 	cmd.Dir = repoPath
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
@@ -636,7 +636,7 @@ func CreatePrWithAI(ctx context.Context, repoPath, branch, baseBranch string) (*
 
 	// Step 5: Create the PR.
 	log.Info("git/CreatePrWithAI: creating PR", "title", title, "baseBranch", baseBranch)
-	createCmd := exec.CommandContext(ctx, "gh", "pr", "create",
+	createCmd := exec.CommandContext(ctx, ghBin(), "pr", "create",
 		"--title", title,
 		"--body", body,
 		"--base", baseBranch,

--- a/v2/internal/git/merge.go
+++ b/v2/internal/git/merge.go
@@ -53,7 +53,7 @@ func MergePr(ctx context.Context, repoPath, branch, method string, autoMerge, de
 		args = append(args, "-d")
 	}
 
-	cmd := exec.CommandContext(ctx, "gh", args...)
+	cmd := exec.CommandContext(ctx, ghBin(), args...)
 	cmd.Dir = repoPath
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -78,7 +78,7 @@ func MergePr(ctx context.Context, repoPath, branch, method string, autoMerge, de
 // DisableAutoMerge cancels a pending --auto merge.
 func DisableAutoMerge(ctx context.Context, repoPath, branch string) error {
 	log.Info("git/DisableAutoMerge: called", "branch", branch)
-	cmd := exec.CommandContext(ctx, "gh", "pr", "merge", branch, "--disable-auto")
+	cmd := exec.CommandContext(ctx, ghBin(), "pr", "merge", branch, "--disable-auto")
 	cmd.Dir = repoPath
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr

--- a/v2/internal/git/operations.go
+++ b/v2/internal/git/operations.go
@@ -12,10 +12,38 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 )
 
 const defaultTimeout = 30 * time.Second
+
+var (
+	ghOnce sync.Once
+	ghPath string
+)
+
+// ghBin returns the absolute path to the gh binary.
+// macOS GUI apps don't inherit the shell PATH, so Homebrew paths are checked explicitly.
+func ghBin() string {
+	ghOnce.Do(func() {
+		if p, err := exec.LookPath("gh"); err == nil {
+			ghPath = p
+			return
+		}
+		for _, candidate := range []string{
+			"/opt/homebrew/bin/gh", // Apple Silicon
+			"/usr/local/bin/gh",    // Intel
+		} {
+			if _, err := os.Stat(candidate); err == nil {
+				ghPath = candidate
+				return
+			}
+		}
+		ghPath = "gh" // last resort: let the OS error surface naturally
+	})
+	return ghPath
+}
 
 // runGit executes a git command in the given repo path with context-based timeout.
 // It returns trimmed stdout on success, or an error containing stderr context.

--- a/v2/internal/git/repo_config.go
+++ b/v2/internal/git/repo_config.go
@@ -82,7 +82,7 @@ func fetchRepoMergeConfig(ctx context.Context, repoPath, ownerRepo string) RepoM
 
 	query := `query($owner:String!,$name:String!){repository(owner:$owner,name:$name){mergeCommitAllowed squashMergeAllowed rebaseMergeAllowed deleteBranchOnMerge viewerDefaultMergeMethod mergeQueue{id}}}`
 
-	cmd := exec.CommandContext(ctx, "gh", "api", "graphql",
+	cmd := exec.CommandContext(ctx, ghBin(), "api", "graphql",
 		"-f", "query="+query,
 		"-F", "owner="+owner,
 		"-F", "name="+name,


### PR DESCRIPTION
## What's in this PR

### Fix: gh CLI path resolution for macOS GUI apps
All 12 `exec.Command("gh", ...)` calls were failing silently in the packaged app because macOS apps launched outside a shell don't inherit the user's Homebrew PATH. The entire PR/CI section in `WorktreeHome` was hidden as a result (it's gated on `ghAvailable()` which was always `false`).

Added `ghBin()` resolver in `v2/internal/git/operations.go` — checks `exec.LookPath` first, then falls back to `/opt/homebrew/bin/gh` (Apple Silicon) and `/usr/local/bin/gh` (Intel). Applied to all calls in `github.go`, `merge.go`, and `repo_config.go`.

### Fix: onboarding identity phase improvements
- `BootTerminal` now forwards the detected git user name (`raw.operator`) through `onBootComplete(operator)` instead of discarding it
- `IdentityBind` accepts `detectedName` as a prop — eliminates the duplicate `git config --global user.name` call that ran independently of the boot scan
- Voice announcement is now conditional: *"Identity detected. Locking in."* when a name was found, *"State your name, Operator."* when it wasn't
- Auto-timer (10s skip) is suppressed when no identity was detected — user must manually enter their name rather than silently advancing with an empty string

---

## Plan: Onboarding Dependency Check Phase (next)

### Problem
Users with `gh` or an AI provider installed in non-standard paths (Homebrew, custom) get no feedback during onboarding — features silently disappear. First-time users don't know they need to install anything.

### Proposed: new `deps-check` phase (between `awakening` and `identity-bind`)

#### What it detects
| Tool | Required | If missing |
|------|----------|------------|
| `git` | Hard — blocks proceed | Show `brew install git`, poll with "Check Again" |
| `gh` CLI | Soft | Show `brew install gh && gh auth login`, "Skip — PR features disabled" |
| AI provider (Claude Code etc.) | Soft | Show install command OR custom path input, "Skip — AI features disabled" |

#### UI behaviour
- Each tool row shows: icon + name + status badge (`✓ found at /path` or `✗ not found`)
- Missing tool exposes a copyable install command inline
- **"Check Again"** button re-probes that specific binary (not full boot scan)
- **git**: no skip allowed — "Check Again" is the only action until found
- **gh / AI**: "Skip for now →" with a one-line consequence note
- Custom path input for AI provider: text field that saves to prefs and feeds into the Go resolver at runtime

#### Go changes needed
- `BootScan()` to also detect `gh` binary path (reuse `ghBin()` logic) and return it
- New Wails binding `ReCheckDep(name string) DepStatus` — lightweight probe of a single binary without re-running the full scan
- Persist custom AI provider path as a pref; update the provider resolver to read it on startup

#### Frontend changes needed
- New phase `deps-check` added to `phaseOrder` and `phaseConfigs` in `phases.ts`
- New component `DepsCheck.tsx` rendering the checklist
- `BootScanData` extended with `ghPath?: string` and `aiProviderPath?: string`
- `BootTerminal` passes extended scan data through `onBootComplete`
- `OnboardingFlow` passes scan data to `DepsCheck` (same pattern as `bootOperator` → `IdentityBind`)

#### Open questions before implementation
1. Should the boot terminal scan *already surface* `gh` status in the typewriter output, or only in the new phase?
2. "Check Again" — full re-scan or single-binary probe?
3. Does the custom AI path pref feed directly into `ghBin()`-style resolution, or is it a manual override only?
4. Hard-block on missing `git` or just a strong warning with forced acknowledgment?