### PR TITLE
fix: instant worktree load on add/clone + expand/collapse-all toggle

### DIFF
--- a/v2/frontend/src/components/sidebar/WorktreeSidebar.tsx
+++ b/v2/frontend/src/components/sidebar/WorktreeSidebar.tsx
@@ -1,9 +1,9 @@
 // Phantom — Left sidebar: project/worktree navigation
 // Author: Subash Karki
 
-import { For, onMount, createSignal } from 'solid-js';
+import { For, Show, onMount, createSignal } from 'solid-js';
 import { LeftRail } from './LeftRail';
-import { ChevronsLeft, FolderPlus, GitBranch, HardDriveDownload, Settings2 } from 'lucide-solid';
+import { ChevronsLeft, ChevronsDownUp, ChevronsUpDown, FolderPlus, GitBranch, HardDriveDownload, Settings2 } from 'lucide-solid';
 import { TextField } from '@kobalte/core/text-field';
 import { Tip } from '@/shared/Tip/Tip';
 import { PhantomModal, phantomModalStyles } from '@/shared/PhantomModal/PhantomModal';
@@ -22,7 +22,11 @@ import {
   setLeftSidebarCollapsed,
   isLeftResizing,
   bootstrapWorktrees,
+  loadProjectWorktrees,
+  expandedProjects,
+  setAllProjectsExpanded,
 } from '@/core/signals/worktrees';
+import { projects } from '@/core/signals/projects';
 import { addProject, browseDirectory, cloneRepository, isGitRepo, initGitRepo } from '@/core/bindings';
 import { showWarningToast } from '@/shared/Toast/Toast';
 import { refreshProjects } from '@/core/signals/projects';
@@ -38,6 +42,7 @@ export function WorktreeSidebar() {
     requestAnimationFrame(() => setMounted(true));
   });
 
+  const allProjectsExpanded = () => expandedProjects().size >= projects().length;
 
   const [gitInitPath, setGitInitPath] = createSignal('');
   const gitInitOpen = () => gitInitPath() !== '';
@@ -55,18 +60,18 @@ export function WorktreeSidebar() {
       setGitInitPath(path);
       return;
     }
-    await addProject(path);
+    const project = await addProject(path);
     await refreshProjects();
-    await bootstrapWorktrees();
+    if (project) await loadProjectWorktrees(project.id);
   }
 
   async function handleConfirmGitInit() {
     const path = gitInitPath();
     setGitInitPath('');
     await initGitRepo(path);
-    await addProject(path);
+    const project = await addProject(path);
     await refreshProjects();
-    await bootstrapWorktrees();
+    if (project) await loadProjectWorktrees(project.id);
   }
 
   const [scanOpen, setScanOpen] = createSignal(false);
@@ -85,9 +90,9 @@ export function WorktreeSidebar() {
   async function handleCloneSubmit(url: string) {
     const dest = await browseDirectory('Select destination directory');
     if (!dest) return;
-    await cloneRepository(url, dest);
+    const project = await cloneRepository(url, dest);
     await refreshProjects();
-    await bootstrapWorktrees();
+    if (project) await loadProjectWorktrees(project.id);
   }
 
   const collapsed = () => leftSidebarCollapsed();
@@ -169,6 +174,18 @@ export function WorktreeSidebar() {
               <HardDriveDownload size={14} />
             </button>
           </Tip>
+          <Show when={projects().length >= 2}>
+            <Tip label={allProjectsExpanded() ? 'Collapse all' : 'Expand all'}>
+              <button
+                class={`${styles.actionButton} ${styles.actionButtonCompact}`}
+                type="button"
+                onClick={() => setAllProjectsExpanded(!allProjectsExpanded())}
+                aria-label={allProjectsExpanded() ? 'Collapse all projects' : 'Expand all projects'}
+              >
+                {allProjectsExpanded() ? <ChevronsDownUp size={14} /> : <ChevronsUpDown size={14} />}
+              </button>
+            </Tip>
+          </Show>
           <Tip label="Manage projects">
             <button
               class={`${styles.actionButton} ${styles.actionButtonCompact}`}

--- a/v2/frontend/src/core/signals/worktrees.ts
+++ b/v2/frontend/src/core/signals/worktrees.ts
@@ -58,7 +58,7 @@ export const activeProject = createMemo(() => {
 });
 
 // Load worktrees for a single project
-async function loadProjectWorktrees(projectId: string): Promise<void> {
+export async function loadProjectWorktrees(projectId: string): Promise<void> {
   try {
     const wts = await listWorktrees(projectId);
     console.log('[worktrees] loaded for project', projectId, wts);
@@ -224,6 +224,20 @@ export function toggleProject(projectId: string): void {
     setPref('expanded_projects', JSON.stringify([...next]));
     return next;
   });
+}
+
+// Expand or collapse every project at once. On collapse, the active worktree's
+// parent project stays expanded so the user keeps sight of what they're working on.
+export function setAllProjectsExpanded(shouldExpand: boolean): void {
+  const next = new Set<string>();
+  if (shouldExpand) {
+    for (const p of projects()) next.add(p.id);
+  } else {
+    const wt = activeWorktree();
+    if (wt) next.add(wt.project_id);
+  }
+  setExpandedProjects(next);
+  setPref('expanded_projects', JSON.stringify([...next]));
 }
 
 // Select the active worktree, persist, and auto-expand its parent project


### PR DESCRIPTION
## Summary

Two small, related sidebar fixes:

1. **Branches now appear instantly when adding or cloning a project.** Previously the new project showed up in the sidebar but its worktrees/branches stayed empty until fsnotify eventually fired a `git:status` event (could take minutes). Root cause: the three handlers in `WorktreeSidebar` called `bootstrapWorktrees()` after the mutation, but that function is intentionally one-shot — it short-circuits via the module-level `worktreesBootstrapped` flag after the first call. New projects' `worktreeMap` entries never got populated until the watcher burped.

   Fix: the handlers now capture the project returned by `addProject` / `cloneRepository` and call `loadProjectWorktrees(project.id)` directly. `bootstrapWorktrees` stays in `onMount` where it belongs.

2. **New toolbar toggle to expand or collapse all projects at once.** Visible when 2+ projects exist. The icon and tooltip flip between `ChevronsDownUp` ("Collapse all") and `ChevronsUpDown` ("Expand all") based on whether every project is currently open. On collapse-all, the active worktree's parent project stays expanded so you keep sight of what you're working on.

## Files changed

- `frontend/src/core/signals/worktrees.ts` — exported `loadProjectWorktrees`, added `setAllProjectsExpanded(bool)`.
- `frontend/src/components/sidebar/WorktreeSidebar.tsx` — three add/clone handlers + new toggle button.

## Test plan

- [ ] Add a fresh repo → default branch shows immediately, no waiting
- [ ] Add a repo that already has multiple `git worktree` checkouts → all of them appear immediately
- [ ] Clone a new repo → branches show immediately
- [ ] Init-git-then-add path → branches show immediately
- [ ] Toolbar toggle hidden with 0 or 1 projects, visible with 2+
- [ ] Click expand-all → every project opens; icon flips to collapse
- [ ] Click collapse-all → every project closes EXCEPT the one containing the active worktree
- [ ] State persists across app restart

## Fun fact

The fsnotify watcher on `.git/index` was unintentionally acting as the bug's safety net — every passing fs event was eventually masking the missing refresh. Took looking at it carefully to realize "branches appear after a few minutes" wasn't a quirk, it was the watcher rescuing us.