### PR TITLE
feat: user-level Phantom MCP + project-scoped edit gate

### DIFF
--- a/v2/Makefile
+++ b/v2/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev build clean test lint sqlc frontend-install frontend-build frontend-typecheck go-build go-test go-lint ci mcp-build docs-llm release release-build release-sign release-notarize release-zip release-dmg
+.PHONY: dev build clean test lint sqlc frontend-install frontend-build frontend-typecheck go-build go-test go-lint ci mcp-build mcp-bundle docs-llm release release-build release-sign release-notarize release-zip release-dmg
 
 # --- Release config ---
 # Auto-load Apple notarization credentials from parent dir (sibling of v2/).
@@ -8,6 +8,7 @@ export APPLE_ID APPLE_APP_SPECIFIC_PASSWORD APPLE_TEAM_ID
 
 APP_NAME      := Phantom
 APP_BUNDLE    := build/bin/$(APP_NAME).app
+APP_MACOS     := $(APP_BUNDLE)/Contents/MacOS
 SIGN_IDENTITY := Developer ID Application: Subash Karki (Z825V2BBX9)
 TEAM_ID       := Z825V2BBX9
 ENTITLEMENTS  := build/darwin/entitlements.plist
@@ -15,12 +16,13 @@ DIST_DIR      := build/dist
 VERSION       := $(shell cat VERSION 2>/dev/null || echo dev)
 
 # Development
-dev:
+dev: mcp-build
 	wails dev
 
-# Production build
-build:
+# Production build — also bundles the phantom-mcp child binary into the .app.
+build: mcp-build
 	wails build -clean
+	$(MAKE) mcp-bundle
 
 # Frontend
 frontend-install:
@@ -88,6 +90,23 @@ go-build:
 mcp-build:
 	go build -o build/bin/phantom-mcp ./cmd/phantom-mcp
 
+# Universal MCP binary used for release builds (matches darwin/universal target).
+mcp-build-universal:
+	GOOS=darwin GOARCH=arm64 go build -trimpath -ldflags "-s -w" -o build/bin/phantom-mcp-arm64 ./cmd/phantom-mcp
+	GOOS=darwin GOARCH=amd64 go build -trimpath -ldflags "-s -w" -o build/bin/phantom-mcp-amd64 ./cmd/phantom-mcp
+	lipo -create -output build/bin/phantom-mcp build/bin/phantom-mcp-arm64 build/bin/phantom-mcp-amd64
+	rm -f build/bin/phantom-mcp-arm64 build/bin/phantom-mcp-amd64
+
+# Copy the compiled phantom-mcp binary next to the main app executable inside
+# the .app bundle so MCP registration can resolve it via os.Executable() at
+# runtime. Idempotent — overwrites any previous copy.
+mcp-bundle:
+	@test -f build/bin/phantom-mcp || (echo "missing build/bin/phantom-mcp — run 'make mcp-build' first"; exit 1)
+	@test -d "$(APP_MACOS)" || (echo "missing $(APP_MACOS) — run 'make build' first"; exit 1)
+	cp build/bin/phantom-mcp "$(APP_MACOS)/phantom-mcp"
+	chmod +x "$(APP_MACOS)/phantom-mcp"
+	@echo "✓ phantom-mcp bundled at $(APP_MACOS)/phantom-mcp"
+
 go-test:
 	go test ./... -v -race
 
@@ -123,9 +142,11 @@ ci: frontend-install frontend-build go-build
 
 release: release-dmg
 
-release-build:
+release-build: mcp-build-universal
 	@echo "==> wails build (universal, trimmed)"
 	wails build -clean -trimpath -platform darwin/universal -ldflags "-s -w"
+	@echo "==> bundling phantom-mcp into .app"
+	$(MAKE) mcp-bundle
 
 release-sign: release-build
 	@echo "==> codesign with hardened runtime"

--- a/v2/frontend/src/screens/onboarding/phases/AIEngineConsent.tsx
+++ b/v2/frontend/src/screens/onboarding/phases/AIEngineConsent.tsx
@@ -1,6 +1,6 @@
 // Author: Subash Karki
 
-import { createSignal, For, onMount } from 'solid-js';
+import { createSignal, For, onMount, Show } from 'solid-js';
 import { Switch as KobalteSwitch } from '@kobalte/core/switch';
 import { playSound } from '../../../core/audio/engine';
 import { AI_FEATURES, buildAIPrefs, defaultAIState } from '../config/ai-features';
@@ -14,13 +14,64 @@ interface AIEngineConsentProps {
   onComplete: (data: Record<string, string>) => void;
 }
 
+interface MCPStatus {
+  registered: boolean;
+  binaryPath: string;
+  stale: boolean;
+  error?: string;
+}
+
+const App = () => (window as any).go?.['app']?.App;
+
+async function getMCPStatus(): Promise<MCPStatus> {
+  try {
+    const raw = await App()?.GetMCPRegistrationStatus?.();
+    if (!raw) return { registered: false, binaryPath: '', stale: false };
+    return raw as MCPStatus;
+  } catch (err) {
+    return {
+      registered: false,
+      binaryPath: '',
+      stale: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+async function repairMCP(): Promise<string> {
+  try {
+    return (await App()?.RepairMCPRegistration?.()) ?? '';
+  } catch (err) {
+    return err instanceof Error ? err.message : String(err);
+  }
+}
+
 export function AIEngineConsent(props: AIEngineConsentProps) {
   const [states, setStates] = createSignal<Record<string, boolean>>(defaultAIState());
   const [paused, setPaused] = createSignal(false);
+  const [mcpStatus, setMcpStatus] = createSignal<MCPStatus | null>(null);
+  const [repairing, setRepairing] = createSignal(false);
 
   onMount(() => {
     playSound('reveal');
+    void refreshStatus();
   });
+
+  async function refreshStatus() {
+    setMcpStatus(await getMCPStatus());
+  }
+
+  async function handleRepair() {
+    setPaused(true);
+    setRepairing(true);
+    const err = await repairMCP();
+    setRepairing(false);
+    if (err) {
+      setMcpStatus({ registered: false, binaryPath: '', stale: false, error: err });
+      return;
+    }
+    await refreshStatus();
+  }
 
   function toggle(key: string, checked: boolean) {
     setPaused(true);
@@ -37,12 +88,10 @@ export function AIEngineConsent(props: AIEngineConsentProps) {
   }
 
   function handleSkip() {
-    // Skip persists nothing — defaults remain unset
     props.onComplete({});
   }
 
   function handleAutoResolve() {
-    // Auto-resolve uses defaults
     props.onComplete(buildAIPrefs(states()));
   }
 
@@ -80,6 +129,29 @@ export function AIEngineConsent(props: AIEngineConsentProps) {
             )}
           </For>
         </div>
+
+        <Show when={mcpStatus()}>
+          {(status) => {
+            const ok = status().registered && !status().stale && !status().error;
+            return (
+              <div class={styles.mcpStatusRow}>
+                <span class={ok ? styles.mcpStatusOk : styles.mcpStatusBad}>
+                  Phantom MCP server: {ok ? 'registered' : 'not registered'}
+                  {status().stale ? ' (stale v1 entry)' : ''}
+                </span>
+                <Show when={!ok}>
+                  <button
+                    class={buttonRecipe({ variant: 'outline', size: 'sm' })}
+                    onClick={() => void handleRepair()}
+                    disabled={repairing()}
+                  >
+                    {repairing() ? 'Repairing…' : 'Repair'}
+                  </button>
+                </Show>
+              </div>
+            );
+          }}
+        </Show>
 
         <div class={styles.actionRow}>
           <button

--- a/v2/frontend/src/screens/onboarding/styles/ai-consent.css.ts
+++ b/v2/frontend/src/screens/onboarding/styles/ai-consent.css.ts
@@ -42,3 +42,24 @@ export const skipRow = style({
   paddingTop: vars.space.sm,
   opacity: 0.7,
 });
+
+export const mcpStatusRow = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: vars.space.md,
+  padding: `${vars.space.sm} 0`,
+  borderTop: `1px solid ${vars.color.border}`,
+  marginTop: vars.space.sm,
+  fontFamily: vars.font.mono,
+  fontSize: vars.fontSize.xs,
+  color: vars.color.textSecondary,
+});
+
+export const mcpStatusOk = style({
+  color: vars.color.success,
+});
+
+export const mcpStatusBad = style({
+  color: vars.color.warning,
+});

--- a/v2/hooks/edit-gate.js
+++ b/v2/hooks/edit-gate.js
@@ -2,12 +2,33 @@
 /**
  * PhantomOS v2 -- PreToolUse Edit Gate
  * Blocks Edit/Write/MultiEdit unless phantom_before_edit was called (when enabled)
- * Only gates SOURCE CODE files — docs, plans, configs pass through freely
+ * Only gates SOURCE CODE files inside a linked Phantom workspace — docs, plans,
+ * configs, and edits outside any linked workspace pass through freely.
  * Falls open if PhantomOS API is unavailable (Claude can't call tools that don't exist)
  * @author Subash Karki
  */
 
 const API = `http://localhost:${process.env.PHANTOM_API_PORT || '3849'}`;
+
+async function fetchJSON(url, ms = 1500, init) {
+  const c = new AbortController();
+  const t = setTimeout(() => c.abort(), ms);
+  try {
+    const res = await fetch(url, { ...init, signal: c.signal });
+    return await res.json();
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+function isInsideAny(filePath, workspaces) {
+  if (!filePath || !Array.isArray(workspaces) || workspaces.length === 0) return false;
+  return workspaces.some((w) => {
+    const root = (w?.path || '').replace(/\/+$/, '');
+    if (!root) return false;
+    return filePath === root || filePath.startsWith(`${root}/`);
+  });
+}
 
 let input = '';
 process.stdin.on('data', (d) => (input += d));
@@ -53,13 +74,22 @@ process.stdin.on('end', async () => {
       process.exit(0);
     }
 
+    // Scope to linked Phantom workspaces. Edits outside any linked workspace
+    // are someone else's problem — Phantom shouldn't gate them.
+    try {
+      const workspaces = await fetchJSON(`${API}/api/workspaces`, 1500);
+      if (!isInsideAny(filePath, workspaces)) {
+        process.exit(0);
+      }
+    } catch {
+      // API down — fail open below the prefs check.
+    }
+
     // Check if edit gate is enabled AND API is reachable
     // If API is down, fail open — Claude can't call phantom_before_edit anyway
     let gateEnabled = false;
     try {
-      const controller = new AbortController();
-      setTimeout(() => controller.abort(), 1500);
-      const prefs = await fetch(`${API}/api/preferences/ai`, { signal: controller.signal }).then((r) => r.json());
+      const prefs = await fetchJSON(`${API}/api/preferences/ai`, 1500);
       gateEnabled = prefs?.['ai.editGate'] === true;
     } catch {
       // API unreachable — fail open, just advise
@@ -71,18 +101,13 @@ process.stdin.on('end', async () => {
 
     if (gateEnabled) {
       // Honour the touch cache: if phantom_before_edit was called for this
-      // path within the TTL, allow the edit through. Means the gate now
-      // does what its description promises ("require dependency analysis
-      // before file modifications") instead of being a binary kill switch.
+      // path within the TTL, allow the edit through.
       let allowed = false;
       try {
-        const c = new AbortController();
-        setTimeout(() => c.abort(), 1500);
-        const res = await fetch(
+        const data = await fetchJSON(
           `${API}/api/edit-gate/check?path=${encodeURIComponent(filePath)}`,
-          { signal: c.signal },
+          1500,
         );
-        const data = await res.json();
         allowed = data?.allowed === true;
       } catch {
         // Check endpoint unreachable — fall through to blocking behaviour
@@ -101,7 +126,14 @@ process.stdin.on('end', async () => {
       }
 
       process.stderr.write(
-        'BLOCKED: Call phantom_before_edit with the target file paths before editing. This provides dependency context and blast radius analysis.',
+        [
+          'BLOCKED: Call `phantom_before_edit` (from the phantom-ai MCP server)',
+          'with this file path before editing.',
+          '',
+          "If the tool isn't available, the phantom-ai MCP server may not be",
+          'registered. Run `/mcp` in Claude Code to check, or set',
+          'PHANTOM_GATE_DISABLE=1 to bypass for this session.',
+        ].join('\n'),
       );
 
       fetch(`${API}/api/hook-health/report`, {

--- a/v2/internal/api/edit_gate.go
+++ b/v2/internal/api/edit_gate.go
@@ -135,3 +135,19 @@ func (s *Server) handleEditGateCheck(w http.ResponseWriter, r *http.Request) {
 		"ttlSec":  int(EditGateTTL.Seconds()),
 	})
 }
+
+// handleListWorkspaces returns the currently linked Phantom workspaces so
+// the edit-gate hook can scope blocking to those paths only. Empty list is
+// returned (not 503) when the dep is unconfigured — the hook treats empty
+// as "no linked workspaces, fail open".
+func (s *Server) handleListWorkspaces(w http.ResponseWriter, _ *http.Request) {
+	if s.deps.ListWorkspaces == nil {
+		writeJSON(w, http.StatusOK, []Workspace{})
+		return
+	}
+	workspaces := s.deps.ListWorkspaces()
+	if workspaces == nil {
+		workspaces = []Workspace{}
+	}
+	writeJSON(w, http.StatusOK, workspaces)
+}

--- a/v2/internal/api/server.go
+++ b/v2/internal/api/server.go
@@ -30,6 +30,13 @@ const DefaultPort = 3849
 // FallbackPort is tried when DefaultPort is busy (e.g. v1 server running).
 const FallbackPort = 3850
 
+// Workspace is the wire shape for /api/workspaces — what the edit-gate hook
+// uses to scope the gate to linked Phantom workspaces only.
+type Workspace struct {
+	Name string `json:"name"`
+	Path string `json:"path"`
+}
+
 // ServerDeps holds external dependencies injected at construction time.
 type ServerDeps struct {
 	// FileIndexers provides graph queries per project. The map key is the
@@ -42,6 +49,11 @@ type ServerDeps struct {
 
 	// DB is the SQLite writer connection for preferences.
 	DB *sql.DB
+
+	// ListWorkspaces returns the currently linked Phantom workspaces. The
+	// edit-gate hook calls /api/workspaces to scope the gate to these paths
+	// only — edits outside any linked workspace pass through untouched.
+	ListWorkspaces func() []Workspace
 }
 
 // hookHealthEntry records the last health report from a hook.
@@ -143,6 +155,9 @@ func (s *Server) registerRoutes() {
 
 	s.mux.HandleFunc("POST /api/edit-gate/touch", s.handleEditGateTouch)
 	s.mux.HandleFunc("GET /api/edit-gate/check", s.handleEditGateCheck)
+
+	// Linked Phantom workspaces — edit-gate hook scopes the gate to these.
+	s.mux.HandleFunc("GET /api/workspaces", s.handleListWorkspaces)
 
 	// Graph (for prompt-enricher hook)
 	s.mux.HandleFunc("GET /api/graph/auto/context", s.handleGraphAutoContext)

--- a/v2/internal/app/app.go
+++ b/v2/internal/app/app.go
@@ -27,6 +27,7 @@ import (
 	"github.com/subashkarki/phantom-os-v2/internal/db"
 	"github.com/subashkarki/phantom-os-v2/internal/gamification"
 	"github.com/subashkarki/phantom-os-v2/internal/git"
+	"github.com/subashkarki/phantom-os-v2/internal/integration"
 	"github.com/subashkarki/phantom-os-v2/internal/linker"
 	"github.com/subashkarki/phantom-os-v2/internal/provider"
 	"github.com/subashkarki/phantom-os-v2/internal/safety"
@@ -218,6 +219,12 @@ func (a *App) Startup(ctx context.Context) {
 	// Start lightweight HTTP API server for Claude Code hook communication.
 	a.startAPIServer()
 
+	// Self-heal MCP registration on every boot. Cheap (single ~/.mcp.json
+	// read), idempotent, and rewrites stale v1 entries left over from
+	// pre-v2 installs without waiting for the user to flip a settings
+	// toggle. Failures are logged, not fatal.
+	go a.selfHealMCPRegistration()
+
 	// Mark orphaned terminals (active in DB but no live PTY) as ended.
 	// Handles crash recovery: terminals that were active when the app last exited.
 	if a.DB != nil {
@@ -377,10 +384,31 @@ func (a *App) startAPIServer() {
 		dbWriter = a.DB.Writer
 	}
 
+	listWorkspacesFn := func() []api.Workspace {
+		if a.DB == nil {
+			return nil
+		}
+		q := db.New(a.DB.Reader)
+		projects, err := q.ListProjects(a.ctx)
+		if err != nil {
+			log.Warn("app: list workspaces for api failed", "err", err)
+			return nil
+		}
+		out := make([]api.Workspace, 0, len(projects))
+		for _, p := range projects {
+			if p.RepoPath == "" {
+				continue
+			}
+			out = append(out, api.Workspace{Name: p.Name, Path: p.RepoPath})
+		}
+		return out
+	}
+
 	a.apiServer = api.NewServer(api.DefaultPort, api.ServerDeps{
-		FileIndexers:  indexersFn,
-		DecisionStore: decisionStore,
-		DB:            dbWriter,
+		FileIndexers:   indexersFn,
+		DecisionStore:  decisionStore,
+		DB:             dbWriter,
+		ListWorkspaces: listWorkspacesFn,
 	})
 
 	go func() {
@@ -388,6 +416,37 @@ func (a *App) startAPIServer() {
 			log.Error("app: api server failed", "err", err)
 		}
 	}()
+}
+
+// selfHealMCPRegistration ensures phantom-ai is registered in ~/.mcp.json
+// with the current binary path on every boot, and that all linked Phantom
+// workspaces have the server enabled in their ~/.claude.json project entry.
+// All failures are logged but never propagated — MCP registration is an
+// enhancement, not critical.
+func (a *App) selfHealMCPRegistration() {
+	if err := integration.RegisterPhantomMCP(); err != nil {
+		log.Error("app: mcp self-heal failed", "err", err)
+		return
+	}
+	log.Info("app: mcp self-heal complete")
+
+	if a.DB == nil {
+		return
+	}
+	q := db.New(a.DB.Reader)
+	projects, err := q.ListProjects(a.ctx)
+	if err != nil {
+		log.Warn("app: mcp self-heal — list projects failed", "err", err)
+		return
+	}
+	paths := make([]string, 0, len(projects))
+	for _, p := range projects {
+		if p.RepoPath != "" {
+			paths = append(paths, p.RepoPath)
+		}
+	}
+	updated, failed := integration.EnsureProjectsHaveMCP(paths)
+	log.Info("app: mcp project enablement", "updated", updated, "failed", failed, "total", len(paths))
 }
 
 // StartFileGraph starts (or restarts) the file graph indexer for a project.

--- a/v2/internal/app/bindings_mcp.go
+++ b/v2/internal/app/bindings_mcp.go
@@ -7,6 +7,7 @@ package app
 import (
 	"github.com/charmbracelet/log"
 
+	"github.com/subashkarki/phantom-os-v2/internal/db"
 	"github.com/subashkarki/phantom-os-v2/internal/integration"
 )
 
@@ -42,6 +43,40 @@ func (a *App) RegisterPhantomMCPBinding() string {
 	if err := integration.RegisterPhantomMCP(); err != nil {
 		log.Error("app: register phantom-ai mcp failed", "err", err)
 		return err.Error()
+	}
+	return ""
+}
+
+// GetMCPRegistrationStatus reports whether the phantom-ai MCP entry is
+// present in ~/.mcp.json and points at the correct binary. Used by the
+// onboarding consent screen to surface a "Repair" CTA when the registration
+// is missing or stale.
+func (a *App) GetMCPRegistrationStatus() integration.MCPRegistrationStatus {
+	return integration.GetMCPRegistrationStatus()
+}
+
+// RepairMCPRegistration re-runs registration (writes ~/.mcp.json + enables
+// in ~/.claude/settings.json) and re-applies per-project enablement for
+// every linked workspace. Returns "" on success, an error string otherwise.
+func (a *App) RepairMCPRegistration() string {
+	if err := integration.RegisterPhantomMCP(); err != nil {
+		log.Error("app: repair mcp registration failed", "err", err)
+		return err.Error()
+	}
+	if a.DB != nil {
+		q := db.New(a.DB.Reader)
+		projects, err := q.ListProjects(a.ctx)
+		if err != nil {
+			log.Warn("app: repair mcp — list projects failed", "err", err)
+			return ""
+		}
+		paths := make([]string, 0, len(projects))
+		for _, p := range projects {
+			if p.RepoPath != "" {
+				paths = append(paths, p.RepoPath)
+			}
+		}
+		integration.EnsureProjectsHaveMCP(paths)
 	}
 	return ""
 }

--- a/v2/internal/app/bindings_projects.go
+++ b/v2/internal/app/bindings_projects.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/subashkarki/phantom-os-v2/internal/db"
 	"github.com/subashkarki/phantom-os-v2/internal/git"
+	"github.com/subashkarki/phantom-os-v2/internal/integration"
 	"github.com/subashkarki/phantom-os-v2/internal/project"
 )
 
@@ -36,6 +37,11 @@ func (a *App) AddProject(repoPath string) (*db.Project, error) {
 	// Return existing project if already registered.
 	rq := db.New(a.DB.Reader)
 	if existing, err := rq.FindProjectByRepoPath(a.ctx, repoPath); err == nil {
+		// Still ensure MCP is enabled for already-linked workspaces in case
+		// the project was added before the per-project enablement existed.
+		if err := integration.EnsureProjectHasMCP(repoPath); err != nil {
+			slog.Warn("AddProject: ensure mcp for existing project failed", "err", err)
+		}
 		return &existing, nil
 	}
 
@@ -88,6 +94,10 @@ func (a *App) AddProject(repoPath string) (*db.Project, error) {
 	}
 	if err := q.CreateWorkspace(a.ctx, wsParams); err != nil {
 		slog.Warn("AddProject: auto-create workspace failed", "err", err)
+	}
+
+	if err := integration.EnsureProjectHasMCP(repoPath); err != nil {
+		slog.Warn("AddProject: ensure mcp project enablement failed", "err", err)
 	}
 
 	return &proj, nil

--- a/v2/internal/integration/mcp_config.go
+++ b/v2/internal/integration/mcp_config.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 )
 
 const (
@@ -17,10 +18,24 @@ const (
 )
 
 // findMCPBinaryPath locates the compiled phantom-mcp Go binary.
-// Walks up from the running binary toward known build/bin locations.
+// Search order:
+//  1. Sibling of the running executable (the .app bundle case — Phantom and
+//     phantom-mcp ship in the same Contents/MacOS directory).
+//  2. Walk up from the executable looking for build/bin layouts (wails dev).
+//  3. Well-known v2 source roots under $HOME (developer machines).
+//  4. PATH lookup.
+//  5. Fallback: best-guess path under ~/phantom-os/v2/build/bin.
 func findMCPBinaryPath() string {
-	// Strategy 1: Walk up from the running binary, checking common output dirs.
 	if exe, err := os.Executable(); err == nil {
+		// Strategy 1: Sibling next to the running binary. This is the
+		// canonical location inside a packaged Phantom.app — both the GUI
+		// binary and phantom-mcp live in Contents/MacOS/.
+		sibling := filepath.Join(filepath.Dir(exe), mcpBinaryName)
+		if _, err := os.Stat(sibling); err == nil {
+			return sibling
+		}
+
+		// Strategy 2: Walk up from the running binary, checking common output dirs.
 		dir := filepath.Dir(exe)
 		for i := 0; i < 8; i++ {
 			candidates := []string{
@@ -41,7 +56,7 @@ func findMCPBinaryPath() string {
 		}
 	}
 
-	// Strategy 2: Well-known v2 source roots relative to home.
+	// Strategy 3: Well-known v2 source roots relative to home.
 	home, _ := os.UserHomeDir()
 	roots := []string{
 		filepath.Join(home, "phantom-os", "v2"),
@@ -57,13 +72,39 @@ func findMCPBinaryPath() string {
 		}
 	}
 
-	// Strategy 3: PATH lookup.
+	// Strategy 4: PATH lookup.
 	if p, err := exec.LookPath(mcpBinaryName); err == nil {
 		return p
 	}
 
 	// Fallback: best-guess path under v2 build dir.
 	return filepath.Join(home, "phantom-os", "v2", "build", "bin", mcpBinaryName)
+}
+
+// isStaleV1Entry reports whether the given server definition is the legacy v1
+// TypeScript stdio entry point. We force-rewrite those even when an entry
+// already exists in ~/.mcp.json.
+func isStaleV1Entry(def map[string]any) bool {
+	cmd, _ := def["command"].(string)
+	if cmd != "npx" {
+		return false
+	}
+	args, _ := def["args"].([]any)
+	hasTsx := false
+	hasStdioEntry := false
+	for _, a := range args {
+		s, ok := a.(string)
+		if !ok {
+			continue
+		}
+		if s == "tsx" {
+			hasTsx = true
+		}
+		if strings.HasSuffix(s, "stdio-entry.ts") {
+			hasStdioEntry = true
+		}
+	}
+	return hasTsx && hasStdioEntry
 }
 
 // RegisterPhantomMCP registers the phantom-ai MCP server globally.
@@ -86,7 +127,6 @@ func RegisterPhantomMCP() error {
 		},
 	}
 
-	// ── ~/.mcp.json ──────────────────────────────────────────────────────
 	mcpPath := filepath.Join(home, ".mcp.json")
 	config := readJSONFile(mcpPath)
 
@@ -95,9 +135,10 @@ func RegisterPhantomMCP() error {
 		servers = make(map[string]any)
 	}
 
-	// Check if already registered with the same binary path (skip write).
 	if existing, ok := servers[serverName].(map[string]any); ok {
-		if cmd, ok := existing["command"].(string); ok && cmd == binaryPath {
+		if isStaleV1Entry(existing) {
+			slog.Info("🧠 MCP rewriting stale v1 entry", "path", mcpPath)
+		} else if cmd, ok := existing["command"].(string); ok && cmd == binaryPath {
 			slog.Info("🧠 MCP already registered with correct path", "path", mcpPath)
 			return ensureEnabledInClaudeSettings(home)
 		}
@@ -134,6 +175,105 @@ func ensureEnabledInClaudeSettings(home string) error {
 	return nil
 }
 
+// EnsureProjectHasMCP ensures phantom-ai appears in the
+// projects.<projectPath>.enabledMcpjsonServers list of ~/.claude.json.
+// Claude Code stores per-project trust state there: a project recorded with
+// an empty enabledMcpjsonServers array opts the project out of MCP servers
+// it would otherwise inherit from the user-global allowlist. Without this,
+// the trust dialog only fires once per CWD, leaving the user permanently
+// opted out for that workspace.
+//
+// Best-effort: missing file or missing project entry are not errors. If the
+// project has not been recorded yet (Claude Code records on first launch in
+// that CWD) we leave a stub entry so the next launch inherits enablement.
+func EnsureProjectHasMCP(projectPath string) error {
+	if projectPath == "" {
+		return nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+
+	claudePath := filepath.Join(home, ".claude.json")
+	cfg := readJSONFile(claudePath)
+
+	projects, _ := cfg["projects"].(map[string]any)
+	if projects == nil {
+		projects = make(map[string]any)
+	}
+
+	entry, _ := projects[projectPath].(map[string]any)
+	if entry == nil {
+		entry = make(map[string]any)
+	}
+
+	enabled, _ := entry["enabledMcpjsonServers"].([]any)
+	if containsString(enabled, serverName) {
+		return nil
+	}
+	entry["enabledMcpjsonServers"] = append(enabled, serverName)
+	projects[projectPath] = entry
+	cfg["projects"] = projects
+
+	if err := writeJSONFile(claudePath, cfg); err != nil {
+		return err
+	}
+	slog.Info("🧠 MCP enabled for project", "project", projectPath)
+	return nil
+}
+
+// EnsureProjectsHaveMCP applies EnsureProjectHasMCP to every supplied path.
+// Returns the count of projects updated and the count that errored. Errors
+// are logged but never aborted — one bad project shouldn't block the others.
+func EnsureProjectsHaveMCP(paths []string) (updated, failed int) {
+	for _, p := range paths {
+		if err := EnsureProjectHasMCP(p); err != nil {
+			slog.Warn("🧠 MCP project enable failed", "project", p, "err", err)
+			failed++
+			continue
+		}
+		updated++
+	}
+	return updated, failed
+}
+
+// MCPRegistrationStatus describes the current state of the phantom-ai MCP
+// entry in ~/.mcp.json. Used by the onboarding repair UI.
+type MCPRegistrationStatus struct {
+	Registered bool   `json:"registered"`
+	BinaryPath string `json:"binaryPath"`
+	Stale      bool   `json:"stale"`
+	Error      string `json:"error,omitempty"`
+}
+
+// GetMCPRegistrationStatus inspects ~/.mcp.json and reports whether the
+// phantom-ai entry exists, points at the expected binary, and is fresh.
+func GetMCPRegistrationStatus() MCPRegistrationStatus {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return MCPRegistrationStatus{Error: err.Error()}
+	}
+	mcpPath := filepath.Join(home, ".mcp.json")
+	cfg := readJSONFile(mcpPath)
+
+	expected := findMCPBinaryPath()
+	servers, _ := cfg["mcpServers"].(map[string]any)
+	entry, _ := servers[serverName].(map[string]any)
+	if entry == nil {
+		return MCPRegistrationStatus{Registered: false, BinaryPath: expected}
+	}
+	if isStaleV1Entry(entry) {
+		return MCPRegistrationStatus{Registered: true, Stale: true, BinaryPath: expected}
+	}
+	cmd, _ := entry["command"].(string)
+	return MCPRegistrationStatus{
+		Registered: cmd == expected,
+		BinaryPath: cmd,
+		Stale:      cmd != expected,
+	}
+}
+
 // UnregisterPhantomMCP removes phantom-ai from ~/.mcp.json and
 // the enabledMcpjsonServers list in ~/.claude/settings.json.
 func UnregisterPhantomMCP() error {
@@ -142,7 +282,6 @@ func UnregisterPhantomMCP() error {
 		return err
 	}
 
-	// ── Remove from ~/.mcp.json ──────────────────────────────────────────
 	mcpPath := filepath.Join(home, ".mcp.json")
 	config := readJSONFile(mcpPath)
 	if servers, ok := config["mcpServers"].(map[string]any); ok {
@@ -157,7 +296,6 @@ func UnregisterPhantomMCP() error {
 		}
 	}
 
-	// ── Remove from enabledMcpjsonServers ────────────────────────────────
 	settingsPath := filepath.Join(home, ".claude", "settings.json")
 	settings := readJSONFile(settingsPath)
 	if enabled, ok := settings["enabledMcpjsonServers"].([]any); ok {


### PR DESCRIPTION
## Summary

Wires up phantom-ai MCP registration so it actually works in any Claude Code session on the machine, scopes the edit gate to linked workspaces only, and surfaces registration status in onboarding so failures stop being silent.

## What changed

- **Makefile** — builds `phantom-mcp` alongside the GUI; `mcp-bundle` target copies it into `Phantom.app/Contents/MacOS` so `os.Executable()` resolves it. Signed recursively in the existing release-sign pass. Universal build via lipo.
- **internal/app/app.go** — runs `RegisterPhantomMCP()` in a goroutine on Startup. Iterates linked workspaces and enables phantom-ai per project so the trust-dialog opt-out doesn't permanently kill the integration.
- **internal/integration/mcp_config.go** — detects v1 `npx tsx stdio-entry.ts` patterns and force-rewrites to the v2 binary path. Resolves binary via `os.Executable` sibling first, falls back to `build/bin` for `wails dev`. `EnsureProjectHasMCP()` writes phantom-ai into `~/.claude.json` `projects.<path>.enabledMcpjsonServers`.
- **internal/app/bindings_projects.go** — `AddProject` calls `EnsureProjectHasMCP` for both new and existing rows.
- **internal/app/bindings_mcp.go** — new `GetMCPRegistrationStatus` + `RepairMCPRegistration` Wails methods for the onboarding UI.
- **internal/api/server.go + edit_gate.go** — `GET /api/workspaces` returns linked workspace paths so the gate hook can scope itself.
- **hooks/edit-gate.js** — queries `/api/workspaces` and exits 0 (allow) for any path outside a linked Phantom workspace. BLOCKED message now names phantom-ai, points at `/mcp`, mentions `PHANTOM_GATE_DISABLE=1`.
- **AIEngineConsent.tsx + ai-consent.css.ts** — status row showing registration state with a Repair button bound to the new bindings.

## Test plan

- [ ] Fresh install on a clean machine — MCP registers automatically on Startup
- [ ] Open Claude Code in a linked Phantom workspace → phantom-ai MCP available without manual config
- [ ] Open Claude Code in a directory outside any workspace → edit-gate exits 0 (no block)
- [ ] Trust-dialog opt-out then quit/relaunch → MCP still works for already-linked projects
- [ ] Onboarding screen shows registration status; Repair button fixes a missing entry
- [ ] `wails dev` resolves the binary from `build/bin`, packaged app resolves it sibling-to-app

## Fun fact

`os.Executable()` returns the path of the **running** binary, not the GUI's bundle path — which is exactly why we ship `phantom-mcp` next to the main executable instead of trying to rebuild the path from the bundle root. One sibling lookup, zero hardcoded `Contents/MacOS` strings.