### PR TITLE
fix: extract repo name from URL for clone destination

### DIFF
--- a/v2/frontend/src/components/WelcomePage.tsx
+++ b/v2/frontend/src/components/WelcomePage.tsx
@@ -9,6 +9,7 @@ import { addProject, browseDirectory, cloneRepository, scanDirectory } from '@/c
 import { refreshProjects } from '@/core/signals/projects';
 import { bootstrapWorktrees } from '@/core/signals/worktrees';
 import { CloneDialog } from '@/shared/CloneDialog/CloneDialog';
+import { showWarningToast } from '@/shared/Toast/Toast';
 import { BootRings } from '@/screens/boot/BootRings';
 
 interface ActionTile {
@@ -33,9 +34,13 @@ export function WelcomePage() {
   async function handleCloneSubmit(url: string) {
     const dest = await browseDirectory('Select destination directory');
     if (!dest) return;
-    await cloneRepository(url, dest);
-    await refreshProjects();
-    await bootstrapWorktrees();
+    try {
+      await cloneRepository(url, dest);
+      await refreshProjects();
+      await bootstrapWorktrees();
+    } catch (err) {
+      showWarningToast('Clone failed', String(err));
+    }
   }
 
   async function handleScan() {

--- a/v2/frontend/src/components/sidebar/WorktreeSidebar.tsx
+++ b/v2/frontend/src/components/sidebar/WorktreeSidebar.tsx
@@ -90,9 +90,13 @@ export function WorktreeSidebar() {
   async function handleCloneSubmit(url: string) {
     const dest = await browseDirectory('Select destination directory');
     if (!dest) return;
-    const project = await cloneRepository(url, dest);
-    await refreshProjects();
-    if (project) await loadProjectWorktrees(project.id);
+    try {
+      const project = await cloneRepository(url, dest);
+      await refreshProjects();
+      if (project) await loadProjectWorktrees(project.id);
+    } catch (err) {
+      showWarningToast('Clone failed', String(err));
+    }
   }
 
   const collapsed = () => leftSidebarCollapsed();

--- a/v2/frontend/src/core/bindings/projects.ts
+++ b/v2/frontend/src/core/bindings/projects.ts
@@ -111,12 +111,8 @@ export async function scanDirectory(parentPath: string): Promise<string[]> {
 }
 
 export async function cloneRepository(url: string, destPath: string): Promise<Project | null> {
-  try {
-    const raw = (await App()?.CloneRepository(url, destPath)) ?? null;
-    return raw ? normalize<Project>(raw) : null;
-  } catch {
-    return null;
-  }
+  const raw = (await App()?.CloneRepository(url, destPath)) ?? null;
+  return raw ? normalize<Project>(raw) : null;
 }
 
 export async function toggleStarProject(id: string): Promise<boolean> {

--- a/v2/internal/app/bindings_projects.go
+++ b/v2/internal/app/bindings_projects.go
@@ -245,9 +245,41 @@ func (a *App) ScanDirectory(parentPath string) []string {
 }
 
 // CloneRepository clones a git repo from url into destPath, then registers it as a project.
+// The repo name is extracted from the URL and appended to destPath so that
+// cloning into an existing non-empty directory (e.g. ~/Code) works correctly.
 func (a *App) CloneRepository(url, destPath string) (*db.Project, error) {
-	if err := git.Clone(a.ctx, url, destPath); err != nil {
+	repoName := repoNameFromURL(url)
+	if repoName == "" {
+		return nil, fmt.Errorf("CloneRepository: cannot extract repo name from URL %q", url)
+	}
+	target := filepath.Join(destPath, repoName)
+	if err := git.Clone(a.ctx, url, target); err != nil {
 		return nil, fmt.Errorf("CloneRepository: %w", err)
 	}
-	return a.AddProject(destPath)
+	return a.AddProject(target)
+}
+
+// repoNameFromURL extracts the repository name from a git URL.
+// Examples:
+//
+//	"https://github.com/user/repo.git" → "repo"
+//	"git@github.com:user/repo.git"     → "repo"
+//	"https://github.com/user/repo"     → "repo"
+func repoNameFromURL(rawURL string) string {
+	u := strings.TrimRight(rawURL, "/")
+	u = strings.TrimSuffix(u, ".git")
+
+	// HTTPS / path-based URLs: last segment after "/"
+	if idx := strings.LastIndex(u, "/"); idx >= 0 {
+		return u[idx+1:]
+	}
+	// SSH format: git@host:user/repo
+	if idx := strings.LastIndex(u, ":"); idx >= 0 {
+		part := u[idx+1:]
+		if slashIdx := strings.LastIndex(part, "/"); slashIdx >= 0 {
+			return part[slashIdx+1:]
+		}
+		return part
+	}
+	return ""
 }


### PR DESCRIPTION
## Summary
- Fixes clone failing when user selects an existing non-empty directory (e.g. `~/Code`) as destination
- Extracts repo name from the clone URL and appends it to `destPath`, so `git clone <url> ~/Code/repo` instead of `git clone <url> ~/Code`
- Adds `repoNameFromURL` helper that handles HTTPS, SSH (`git@host:user/repo`), and `.git` suffix variants

Closes #13