### PR TITLE
fix(mcp): surface registration failures + drop hardcoded fallback path

### DIFF
--- a/v2/frontend/src/app.tsx
+++ b/v2/frontend/src/app.tsx
@@ -45,6 +45,7 @@ import { DocsScreen } from './screens/docs';
 import { SystemCockpit } from './screens/system/SystemCockpit';
 import { XPGainFloat, LevelUpCelebration, RankUpCelebration, AchievementToastWatcher } from './shared/Gamification';
 import { bootstrapGamification } from './core/signals/gamification';
+import { bootstrapMCPRegistrationListener } from './core/signals/mcp';
 import { AICommandCenter } from './components/ai-command-center/AICommandCenter';
 
 export function App() {
@@ -81,6 +82,13 @@ export function App() {
     bootstrapApp();
     bootstrapSessions();
     bootstrapProjects();
+
+    // Toast surfaces for MCP self-heal failures (issue #10). Listener stays
+    // active for the life of the app — registered before self-heal can fire
+    // since the Go side's selfHealMCPRegistration runs in a goroutine kicked
+    // off at Startup. Any race here is benign: the toast is informational and
+    // self-heal also runs on every subsequent boot.
+    bootstrapMCPRegistrationListener();
 
     // Restore the last-active worktree BEFORE flipping ready=true so the
     // initial render lands on the workspace instead of flashing WelcomePage.

--- a/v2/frontend/src/core/signals/mcp.ts
+++ b/v2/frontend/src/core/signals/mcp.ts
@@ -3,6 +3,7 @@
 
 import { createSignal, createResource } from 'solid-js';
 import { listMCPServers, toggleMCPServer as toggleBinding, type MCPServer } from '@/core/bindings/mcp';
+import { showWarningToast } from '@/shared/Toast/Toast';
 
 const [mcpManagerOpen, setMcpManagerOpen] = createSignal(false);
 
@@ -30,6 +31,42 @@ export async function toggleMcpServer(name: string, enabled: boolean): Promise<s
     mutateMcpServers((prev) => (prev ?? []).map((s) => (s.name === name ? { ...s, enabled: !enabled } : s)));
   }
   return err;
+}
+
+/**
+ * Backend payload for `mcp:registration-failed`. Emitted by the Go layer
+ * when self-heal or manual Repair fails to write ~/.mcp.json or enable
+ * phantom-ai for a linked project.
+ */
+interface MCPRegistrationFailedPayload {
+  phase: 'register' | 'enable-projects';
+  error: string;
+  hint?: string;
+}
+
+/**
+ * Bootstrap the toast listener for MCP registration failures.
+ *
+ * Issue #10: registration errors used to be silently swallowed in a
+ * background goroutine, leaving users staring at "not registered" with
+ * no explanation. We surface them as a warning toast that points the
+ * user at the Repair button in the AI Engine settings.
+ *
+ * Idempotent — call once at app boot. Uses the global runtime listener
+ * (no Solid `onCleanup` because this never unmounts).
+ */
+export function bootstrapMCPRegistrationListener(): void {
+  if (!window.runtime?.EventsOn) return;
+  window.runtime.EventsOn('mcp:registration-failed', (...args: unknown[]) => {
+    const payload = args[0] as MCPRegistrationFailedPayload | undefined;
+    if (!payload) return;
+    const title =
+      payload.phase === 'enable-projects'
+        ? 'Phantom MCP: project enablement failed'
+        : 'Phantom MCP registration failed';
+    const detail = payload.hint ? `${payload.hint}\n\n${payload.error}` : payload.error;
+    showWarningToast(title, detail);
+  });
 }
 
 export { mcpServers, mcpManagerOpen, refreshMcpServers };

--- a/v2/internal/app/app.go
+++ b/v2/internal/app/app.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -421,11 +423,13 @@ func (a *App) startAPIServer() {
 // selfHealMCPRegistration ensures phantom-ai is registered in ~/.mcp.json
 // with the current binary path on every boot, and that all linked Phantom
 // workspaces have the server enabled in their ~/.claude.json project entry.
-// All failures are logged but never propagated — MCP registration is an
-// enhancement, not critical.
+// Failures are logged AND surfaced to the frontend via mcp:registration-failed
+// so the user gets a toast pointing them at the Repair button instead of a
+// silent "not registered" status.
 func (a *App) selfHealMCPRegistration() {
 	if err := integration.RegisterPhantomMCP(); err != nil {
 		log.Error("app: mcp self-heal failed", "err", err)
+		a.emitMCPFailure("register", err)
 		return
 	}
 	log.Info("app: mcp self-heal complete")
@@ -447,6 +451,43 @@ func (a *App) selfHealMCPRegistration() {
 	}
 	updated, failed := integration.EnsureProjectsHaveMCP(paths)
 	log.Info("app: mcp project enablement", "updated", updated, "failed", failed, "total", len(paths))
+	if failed > 0 {
+		a.emitMCPFailure("enable-projects", fmt.Errorf("%d of %d project(s) failed to enable phantom-ai (see logs)", failed, len(paths)))
+	}
+}
+
+// emitMCPFailure surfaces an MCP registration error to the frontend via the
+// mcp:registration-failed event. The frontend listener turns it into a toast
+// pointing the user at the Repair button. Permission errors get an extra
+// hint mentioning the offending file path so the user knows what to chown.
+func (a *App) emitMCPFailure(phase string, err error) {
+	if err == nil || a.ctx == nil {
+		return
+	}
+	payload := map[string]any{
+		"phase": phase,
+		"error": err.Error(),
+	}
+	if hint := mcpErrorHint(err); hint != "" {
+		payload["hint"] = hint
+	}
+	wailsRuntime.EventsEmit(a.ctx, EventMCPRegistrationFailed, payload)
+}
+
+// mcpErrorHint returns a user-friendly remediation hint for known error
+// shapes — primarily permission failures writing to ~/.mcp.json or
+// ~/.claude/settings.json.
+func mcpErrorHint(err error) string {
+	if err == nil {
+		return ""
+	}
+	if errors.Is(err, fs.ErrPermission) || strings.Contains(err.Error(), "permission denied") {
+		return "Permission denied writing config. Check ownership of ~/.mcp.json and ~/.claude/settings.json, then click Repair."
+	}
+	if strings.Contains(err.Error(), "phantom-mcp binary not found") {
+		return "Phantom couldn't locate the phantom-mcp helper binary. Reinstall Phantom or rebuild the helper, then click Repair."
+	}
+	return ""
 }
 
 // StartFileGraph starts (or restarts) the file graph indexer for a project.

--- a/v2/internal/app/bindings_mcp.go
+++ b/v2/internal/app/bindings_mcp.go
@@ -5,6 +5,8 @@
 package app
 
 import (
+	"fmt"
+
 	"github.com/charmbracelet/log"
 
 	"github.com/subashkarki/phantom-os-v2/internal/db"
@@ -42,6 +44,7 @@ func (a *App) ToggleMCPServer(name string, enabled bool) string {
 func (a *App) RegisterPhantomMCPBinding() string {
 	if err := integration.RegisterPhantomMCP(); err != nil {
 		log.Error("app: register phantom-ai mcp failed", "err", err)
+		a.emitMCPFailure("register", err)
 		return err.Error()
 	}
 	return ""
@@ -58,9 +61,12 @@ func (a *App) GetMCPRegistrationStatus() integration.MCPRegistrationStatus {
 // RepairMCPRegistration re-runs registration (writes ~/.mcp.json + enables
 // in ~/.claude/settings.json) and re-applies per-project enablement for
 // every linked workspace. Returns "" on success, an error string otherwise.
+// Also emits mcp:registration-failed so the toast listener fires whether the
+// user clicked Repair from onboarding or the MCP manager.
 func (a *App) RepairMCPRegistration() string {
 	if err := integration.RegisterPhantomMCP(); err != nil {
 		log.Error("app: repair mcp registration failed", "err", err)
+		a.emitMCPFailure("register", err)
 		return err.Error()
 	}
 	if a.DB != nil {
@@ -76,7 +82,10 @@ func (a *App) RepairMCPRegistration() string {
 				paths = append(paths, p.RepoPath)
 			}
 		}
-		integration.EnsureProjectsHaveMCP(paths)
+		_, failed := integration.EnsureProjectsHaveMCP(paths)
+		if failed > 0 {
+			a.emitMCPFailure("enable-projects", fmt.Errorf("%d of %d project(s) failed to enable phantom-ai (see logs)", failed, len(paths)))
+		}
 	}
 	return ""
 }

--- a/v2/internal/app/events.go
+++ b/v2/internal/app/events.go
@@ -46,6 +46,10 @@ const (
 	EventPrMerged     = "pr:merged"      // payload: { worktreeId, prNumber }
 	EventMergeFailed  = "pr:merge-failed" // payload: { worktreeId, prNumber, message }
 
+	// MCP self-heal / repair failure surfacing.
+	// payload: { phase: "register" | "enable-projects", error: string, hint?: string }
+	EventMCPRegistrationFailed = "mcp:registration-failed"
+
 	EventGamificationXPGained           = "gamification:xp_gained"            // payload: {amount, total, trigger}
 	EventGamificationLevelUp            = "gamification:level_up"             // payload: {level, xpToNext}
 	EventGamificationRankUp             = "gamification:rank_up"              // payload: {rank, title}

--- a/v2/internal/integration/mcp_config.go
+++ b/v2/internal/integration/mcp_config.go
@@ -5,6 +5,7 @@
 package integration
 
 import (
+	"fmt"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -24,15 +25,18 @@ const (
 //  2. Walk up from the executable looking for build/bin layouts (wails dev).
 //  3. Well-known v2 source roots under $HOME (developer machines).
 //  4. PATH lookup.
-//  5. Fallback: best-guess path under ~/phantom-os/v2/build/bin.
-func findMCPBinaryPath() string {
+//
+// Returns an error if every strategy misses. Callers MUST treat that as a
+// hard failure and skip writing the MCP entry — a broken path in ~/.mcp.json
+// is worse than no entry at all (Claude Code spawns and immediately fails).
+func findMCPBinaryPath() (string, error) {
 	if exe, err := os.Executable(); err == nil {
 		// Strategy 1: Sibling next to the running binary. This is the
 		// canonical location inside a packaged Phantom.app — both the GUI
 		// binary and phantom-mcp live in Contents/MacOS/.
 		sibling := filepath.Join(filepath.Dir(exe), mcpBinaryName)
 		if _, err := os.Stat(sibling); err == nil {
-			return sibling
+			return sibling, nil
 		}
 
 		// Strategy 2: Walk up from the running binary, checking common output dirs.
@@ -45,7 +49,7 @@ func findMCPBinaryPath() string {
 			}
 			for _, c := range candidates {
 				if _, err := os.Stat(c); err == nil {
-					return c
+					return c, nil
 				}
 			}
 			parent := filepath.Dir(dir)
@@ -67,18 +71,17 @@ func findMCPBinaryPath() string {
 		for _, sub := range []string{"build/bin", "bin"} {
 			candidate := filepath.Join(root, sub, mcpBinaryName)
 			if _, err := os.Stat(candidate); err == nil {
-				return candidate
+				return candidate, nil
 			}
 		}
 	}
 
 	// Strategy 4: PATH lookup.
 	if p, err := exec.LookPath(mcpBinaryName); err == nil {
-		return p
+		return p, nil
 	}
 
-	// Fallback: best-guess path under v2 build dir.
-	return filepath.Join(home, "phantom-os", "v2", "build", "bin", mcpBinaryName)
+	return "", fmt.Errorf("phantom-mcp binary not found (checked sibling of executable, walked-up build dirs, common $HOME source roots, and $PATH)")
 }
 
 // isStaleV1Entry reports whether the given server definition is the legacy v1
@@ -117,7 +120,10 @@ func RegisterPhantomMCP() error {
 		return err
 	}
 
-	binaryPath := findMCPBinaryPath()
+	binaryPath, err := findMCPBinaryPath()
+	if err != nil {
+		return fmt.Errorf("resolve phantom-mcp binary: %w", err)
+	}
 
 	serverDef := map[string]any{
 		"command": binaryPath,
@@ -257,9 +263,23 @@ func GetMCPRegistrationStatus() MCPRegistrationStatus {
 	mcpPath := filepath.Join(home, ".mcp.json")
 	cfg := readJSONFile(mcpPath)
 
-	expected := findMCPBinaryPath()
+	expected, resolveErr := findMCPBinaryPath()
 	servers, _ := cfg["mcpServers"].(map[string]any)
 	entry, _ := servers[serverName].(map[string]any)
+
+	// If we can't resolve the expected binary, surface that as an error in
+	// the status so the UI can prompt the user. The recorded entry (if any)
+	// might still be valid, so we report what's on disk rather than overwriting.
+	if resolveErr != nil {
+		cmd, _ := entry["command"].(string)
+		return MCPRegistrationStatus{
+			Registered: entry != nil,
+			BinaryPath: cmd,
+			Stale:      entry != nil && isStaleV1Entry(entry),
+			Error:      resolveErr.Error(),
+		}
+	}
+
 	if entry == nil {
 		return MCPRegistrationStatus{Registered: false, BinaryPath: expected}
 	}


### PR DESCRIPTION
## Summary

- **Drop hardcoded fallback path** — `findMCPBinaryPath()` now returns an error instead of guessing `~/phantom-os/v2/build/bin/phantom-mcp` when all resolution strategies fail. `RegisterPhantomMCP` refuses to write a broken entry. (Closes #11)
- **Surface registration failures via toast** — `selfHealMCPRegistration()` emits an `mcp:registration-failed` Wails event with `{ phase, error, hint? }` payload. Frontend global listener turns it into a warning toast pointing at the Repair button. Permission errors include the file path; missing-binary errors suggest reinstall. Same path used by manual Repair. (Closes #10)

## Files changed

| File | Change |
|------|--------|
| `internal/integration/mcp_config.go` | `findMCPBinaryPath` returns `(string, error)`, removes hardcoded fallback |
| `internal/app/app.go` | `selfHealMCPRegistration` emits Wails event on failure |
| `internal/app/bindings_mcp.go` | `RepairMCPRegistration` emits same event on failure |
| `internal/app/events.go` | New `mcp:registration-failed` event constant |
| `frontend/src/app.tsx` | Bootstraps global MCP failure listener |
| `frontend/src/core/signals/mcp.ts` | New signal + event handler for registration failures |

## Test plan

- [ ] Install Phantom in a non-default location → verify MCP entry is NOT written (no broken path)
- [ ] Break permissions on `~/.mcp.json` → launch Phantom → verify toast appears with hint
- [ ] Click Repair with broken permissions → verify toast appears
- [ ] Normal install → verify MCP registration still works as before
- [ ] Verify `GetMCPRegistrationStatus` surfaces resolution error in UI

---

> Fun fact: The first version of `git clone` was written in a shell script. We've come a long way — now we clone repos from GUI apps and still manage to mess up the paths.