### PR TITLE
feat(composer): wire Phantom UI through the AI engine

### DIFF
--- a/v2/internal/app/app.go
+++ b/v2/internal/app/app.go
@@ -21,6 +21,7 @@ import (
 	graphctx "github.com/subashkarki/phantom-os-v2/internal/ai/graph"
 	"github.com/subashkarki/phantom-os-v2/internal/ai/graph/filegraph"
 	"github.com/subashkarki/phantom-os-v2/internal/ai/knowledge"
+	"github.com/subashkarki/phantom-os-v2/internal/ai/orchestrator"
 	"github.com/subashkarki/phantom-os-v2/internal/ai/strategies"
 	"github.com/subashkarki/phantom-os-v2/internal/api"
 	"github.com/subashkarki/phantom-os-v2/internal/branding"
@@ -218,6 +219,11 @@ func (a *App) Startup(ctx context.Context) {
 		a.initFileGraph()
 	}
 
+	// Wire the AI engine into the Composer service so desktop turns get the
+	// same strategy selection + decision recording the MCP server already
+	// gives external Claude Code users. Mirrors cmd/phantom-mcp/main.go.
+	a.wireComposerEngine()
+
 	// Start lightweight HTTP API server for Claude Code hook communication.
 	a.startAPIServer()
 
@@ -353,6 +359,50 @@ func (a *App) initFileGraph() {
 		})
 		log.Info("app: file graph lookup wired (lazy mode)")
 	}
+}
+
+// wireComposerEngine assembles orchestrator.Dependencies from the same
+// knowledge stack the MCP server uses (cmd/phantom-mcp/main.go) and hands
+// it to the Composer service. Each component is best-effort: a nil store
+// degrades gracefully inside orchestrator.Process. The Indexer field is
+// left nil here — the Composer turn supplies its CWD, but the file-graph
+// pool is keyed by project ID, not path. Resolving a project from CWD on
+// every turn is its own concern; YAGNI for v0.
+func (a *App) wireComposerEngine() {
+	if a.Composer == nil || a.DB == nil {
+		return
+	}
+
+	deps := orchestrator.Dependencies{}
+
+	if ds, err := knowledge.NewDecisionStore(a.DB.Writer); err == nil {
+		deps.Decisions = ds
+	} else {
+		log.Warn("app: composer engine — decision store init failed", "err", err)
+	}
+
+	if comp, err := knowledge.NewCompactor(a.DB.Writer); err == nil {
+		deps.Compactor = comp
+	} else {
+		log.Warn("app: composer engine — compactor init failed", "err", err)
+	}
+
+	perf := strategies.NewPerformanceStore()
+	if err := perf.Load(a.DB.Reader); err != nil {
+		log.Warn("app: composer engine — performance load failed (starting empty)", "err", err)
+	}
+	deps.Performance = perf
+
+	autoTune := strategies.NewThresholdTracker()
+	if err := autoTune.LoadThresholds(a.DB.Reader); err != nil {
+		log.Warn("app: composer engine — auto-tune load failed (using defaults)", "err", err)
+	}
+	deps.AutoTune = autoTune
+
+	deps.GapDetector = strategies.NewGapDetector()
+
+	a.Composer.SetEngineDeps(deps)
+	log.Info("app: composer engine wired")
 }
 
 // startAPIServer creates and starts the HTTP API server that Claude Code hooks

--- a/v2/internal/composer/service.go
+++ b/v2/internal/composer/service.go
@@ -28,6 +28,8 @@ import (
 
 	"github.com/charmbracelet/log"
 	"github.com/google/uuid"
+
+	"github.com/subashkarki/phantom-os-v2/internal/ai/orchestrator"
 )
 
 const (
@@ -56,6 +58,12 @@ type Service struct {
 	// once. First turn uses `--session-id <uuid>` to create. Subsequent
 	// turns use `--resume <uuid>` because claude rejects --session-id reuse.
 	sessionStarted map[string]bool
+
+	// engineDeps wires Phantom's AI engine (orchestrator + knowledge stores
+	// + verifier) into every Composer turn. When zero-valued, Send falls
+	// back to the raw user prompt with no strategy enrichment and no
+	// outcome recording — same behaviour as before this connection landed.
+	engineDeps orchestrator.Dependencies
 }
 
 // NewService constructs a Composer service. emit should be wired to
@@ -68,6 +76,15 @@ func NewService(writer *sql.DB, emit func(string, interface{})) *Service {
 		sessions:       make(map[string]string),
 		sessionStarted: make(map[string]bool),
 	}
+}
+
+// SetEngineDeps wires Phantom's AI engine into the Composer service. Call
+// this after construction, before Wails Startup completes. Passing a
+// zero-valued Dependencies disables engine enrichment; orchestrator.Process
+// degrades gracefully when individual fields (Decisions, Indexer, etc.) are
+// nil so partial wiring is safe.
+func (s *Service) SetEngineDeps(deps orchestrator.Dependencies) {
+	s.engineDeps = deps
 }
 
 // ---------------------------------------------------------------------------
@@ -126,13 +143,58 @@ func (s *Service) Send(ctx context.Context, args SendArgs) (string, error) {
 	// Build the prompt with @file mentions inlined as <file> tags.
 	prompt := buildPromptWithMentions(args.Prompt, args.Mentions, args.CWD)
 
+	// Route through Phantom's AI engine: pick a strategy, gather graph
+	// context, record a decision. Skipped entirely in NoContext mode (the
+	// user explicitly asked for no workspace awareness) or when the engine
+	// isn't wired. The orchestrator returns a deterministic enriched prompt
+	// in result.Output.Text — we prepend it as a directive prelude so the
+	// CLI sees strategy guidance before the user's raw goal.
+	var decisionID string
+	if !args.NoContext {
+		if result, err := orchestrator.Process(ctx, s.engineDeps, orchestrator.ProcessInput{
+			Goal:        args.Prompt,
+			ActiveFiles: mentionPaths(args.Mentions, args.CWD),
+		}); err == nil && result != nil {
+			if result.Learning != nil {
+				decisionID = result.Learning.DecisionID
+			}
+			if directive := strings.TrimSpace(result.Output.Text); directive != "" && directive != strings.TrimSpace(args.Prompt) {
+				prompt = directive + "\n\n" + prompt
+			}
+		} else if err != nil {
+			// Surface but don't bypass — KISS, fail loud.
+			log.Warn("composer: orchestrator process failed", "err", err)
+		}
+	}
+
 	runCtx, cancel := context.WithCancel(ctx)
 	s.mu.Lock()
 	s.runs[args.PaneID] = cancel
 	s.mu.Unlock()
 
-	go s.run(runCtx, cliPath, args, sessionID, isResume, turnID, prompt)
+	go s.run(runCtx, cliPath, args, sessionID, isResume, turnID, prompt, decisionID)
 	return turnID, nil
+}
+
+// mentionPaths flattens Mentions into absolute paths for the orchestrator.
+// Empty / unresolved entries are dropped — empty input is fine, the
+// orchestrator handles it.
+func mentionPaths(mentions []Mention, cwd string) []string {
+	if len(mentions) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(mentions))
+	for _, m := range mentions {
+		p := m.Path
+		if p == "" {
+			continue
+		}
+		if !filepath.IsAbs(p) && cwd != "" {
+			p = filepath.Join(cwd, p)
+		}
+		out = append(out, p)
+	}
+	return out
 }
 
 // NewConversation drops the cached session for a pane so the next Send
@@ -294,12 +356,15 @@ func (s *Service) DeleteSession(ctx context.Context, sessionID string) error {
 // Internal — run loop
 // ---------------------------------------------------------------------------
 
-func (s *Service) run(ctx context.Context, cliPath string, args SendArgs, sessionID string, isResume bool, turnID, prompt string) {
+func (s *Service) run(ctx context.Context, cliPath string, args SendArgs, sessionID string, isResume bool, turnID, prompt, decisionID string) {
 	defer func() {
 		s.mu.Lock()
 		delete(s.runs, args.PaneID)
 		s.mu.Unlock()
 	}()
+	// Decision-keyed verifier outcome runs in Connection #2; threaded through
+	// the run goroutine so the close-the-loop call has the same lifecycle.
+	_ = decisionID
 
 	// First turn: --session-id <id> creates the session.
 	// Subsequent turns: --resume <id> attaches to the existing one.

--- a/v2/internal/composer/service.go
+++ b/v2/internal/composer/service.go
@@ -30,6 +30,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/subashkarki/phantom-os-v2/internal/ai/orchestrator"
+	"github.com/subashkarki/phantom-os-v2/internal/ai/verifier"
 )
 
 const (
@@ -362,9 +363,10 @@ func (s *Service) run(ctx context.Context, cliPath string, args SendArgs, sessio
 		delete(s.runs, args.PaneID)
 		s.mu.Unlock()
 	}()
-	// Decision-keyed verifier outcome runs in Connection #2; threaded through
-	// the run goroutine so the close-the-loop call has the same lifecycle.
-	_ = decisionID
+	// Close the learning loop: after every Composer turn (success, error, or
+	// cancel) run the project verifier and write the outcome to ai_outcomes.
+	// Async + best-effort — must never block the next user prompt.
+	defer s.recordVerifierOutcome(decisionID, args.CWD)
 
 	// First turn: --session-id <id> creates the session.
 	// Subsequent turns: --resume <id> attaches to the existing one.
@@ -656,6 +658,61 @@ func (s *Service) cancelExisting(paneID string) {
 	if ok {
 		cancel()
 	}
+}
+
+// recordVerifierOutcome runs the project verifier (typecheck + tests) against
+// the worktree the turn ran in and writes the result to ai_outcomes keyed
+// by the orchestrator's decision ID. Spawned in a goroutine so the user's
+// next prompt never blocks on test runs. No-ops cleanly when:
+//   - the engine isn't wired (DecisionStore == nil)
+//   - the orchestrator never recorded a decision (decisionID == "")
+//   - the turn had no project root (NoContext mode, fresh temp dir, etc.)
+//
+// When the project type isn't recognised we still record an outcome so the
+// learning loop sees signal — flagged via reason="verifier_unavailable".
+func (s *Service) recordVerifierOutcome(decisionID, projectRoot string) {
+	if s.engineDeps.Decisions == nil || decisionID == "" || strings.TrimSpace(projectRoot) == "" {
+		return
+	}
+	go func() {
+		// 5 minute ceiling: typecheck + tests should finish well under
+		// this; the cap protects against a pathological project hanging
+		// the verifier goroutine forever.
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+
+		if verifier.DetectProjectType(projectRoot) == "" {
+			_ = s.engineDeps.Decisions.RecordOutcome(decisionID, false, "verifier_unavailable")
+			return
+		}
+
+		result := verifier.Verify(ctx, projectRoot)
+		reason := summariseVerifier(result)
+		if err := s.engineDeps.Decisions.RecordOutcome(decisionID, result.AllPassed, reason); err != nil {
+			log.Warn("composer: record verifier outcome", "decision_id", decisionID, "err", err)
+		}
+	}()
+}
+
+// summariseVerifier flattens the per-command verifier results into a single
+// short reason string. On success returns "verifier_passed"; on failure
+// returns the first failing command + its truncated output (the verifier
+// already caps Output at 500 chars).
+func summariseVerifier(v verifier.ProjectVerification) string {
+	if v.AllPassed {
+		return "verifier_passed"
+	}
+	for _, r := range v.Results {
+		if !r.Passed {
+			out := strings.TrimSpace(r.Output)
+			if out == "" {
+				return fmt.Sprintf("verifier_failed:%s exit=%d", r.Command, r.ExitCode)
+			}
+			return fmt.Sprintf("verifier_failed:%s exit=%d %s", r.Command, r.ExitCode, out)
+		}
+	}
+	// No commands ran but AllPassed=false (shouldn't happen, but stay safe).
+	return "verifier_failed:no_results"
 }
 
 func parseResult(raw map[string]json.RawMessage) (int64, int64, float64) {


### PR DESCRIPTION
## Summary

Phantom's AI engine (orchestrator + 7 strategies + decision/performance stores + verifier) was fully wired for **external Claude Code users via MCP**, but Phantom's own Composer pane bypassed it entirely — `internal/composer/service.go` spawned `claude -p` with zero strategy selection, zero decision recording, zero outcome capture.

This PR plugs Composer into the engine. Two connections:

1. **Composer → Orchestrator** (`internal/composer/service.go` + `internal/app/app.go`) — before spawning Claude, call `orchestrator.Process()` to run the full strategy selection pipeline. Capture `decisionID` for outcome correlation. Mirrors the wiring pattern from `cmd/phantom-mcp/main.go`.
2. **Verifier → RecordOutcome** — after the turn ends, run `verifier.Verify(projectRoot)` in a goroutine and call `decisions.RecordOutcome(decisionID, AllPassed, summary)`. Works regardless of `--dangerously-skip-permissions` (no accept/reject UX dependency — verifier pass/fail is the success signal).

After this, the auto-tune feedback loop closes for the first time. `ai_decisions` and `ai_outcomes` start filling with real data per Composer turn.

## Smoke test

After running a Composer turn:

\`\`\`bash
sqlite3 ~/.phantom-os/phantom.db \\
  \"SELECT id, goal, strategy_id FROM ai_decisions ORDER BY created_at DESC LIMIT 3;\"
sqlite3 ~/.phantom-os/phantom.db \\
  \"SELECT decision_id, success, failure_reason FROM ai_outcomes ORDER BY created_at DESC LIMIT 3;\"
\`\`\`

A new \`ai_decisions\` row should appear immediately after Send; outcome rows referencing it land within ~30-60s of the turn finishing.

## Known follow-ups (separate PRs)

- **Graph context degraded** — \`Dependencies.Indexer\` is currently \`nil\` because there's no CWD-to-project resolver yet. Strategy selection runs without blast-radius / neighbor-file data. Follow-up PR will add the resolver.
- **Double outcome rows** — \`orchestrator.Process()\` already writes an optimistic \`RecordOutcome(id, true, \"\")\` after enrichment, before any verifier signal. Now this PR adds a second outcome row from verifier. \`GetSuccessRate\` blends both — skews learning toward over-optimism. Follow-up PR will tag outcomes with a phase/source so verifier-only signal can be queried cleanly.

## Files changed

- \`internal/composer/service.go\` — \`engineDeps\` field, \`SetEngineDeps\`, \`mentionPaths\`, \`orchestrator.Process\` call, \`recordVerifierOutcome\`, \`summariseVerifier\`
- \`internal/app/app.go\` — \`wireComposerEngine()\` in Startup, mirrors phantom-mcp knowledge stack wiring

## Test plan

- [ ] \`wails dev\`: send a Composer turn, run the two SQL queries above, confirm rows land
- [ ] Send a turn that produces broken code — verify outcome row records \`success=false\` with verifier failure summary
- [ ] Send a turn in a project with no recognized type — verify outcome row records with \`reason: verifier_unavailable\` and doesn't crash
- [ ] Confirm verifier goroutine doesn't block the next user prompt (5min timeout enforces this)

## Fun fact

The orchestrator records \`RecordOutcome(id, true, \"\")\` immediately after enrichment — i.e. \"strategy selection didn't crash\" gets logged as a successful outcome before the LLM has even thought about the prompt. That's been quietly polluting the learning data since it shipped. Spotted only because we now have a second writer to compare it against. Follow-up PR fixes this with a \`phase\` column.