### PR TITLE
fix(verifier): resolve project root in monorepos with no top-level marker

### DIFF
--- a/v2/internal/ai/verifier/verifier.go
+++ b/v2/internal/ai/verifier/verifier.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -93,6 +94,35 @@ func DetectProjectType(projectRoot string) string {
 	return ""
 }
 
+// ResolveVerifyRoot returns the directory where verification should run.
+// If projectRoot itself contains a known marker, it's returned unchanged.
+// Otherwise we scan one level of immediate children — common monorepo
+// layout (e.g. proxy/go.mod, app/package.json) — and return the first
+// child whose marker matches. Returns ("", "") if nothing is found.
+//
+// Stays one level deep on purpose: KISS, predictable, no surprises from
+// vendored test fixtures buried five levels in.
+func ResolveVerifyRoot(projectRoot string) (dir string, projectType string) {
+	if t := DetectProjectType(projectRoot); t != "" {
+		return projectRoot, t
+	}
+
+	entries, err := os.ReadDir(projectRoot)
+	if err != nil {
+		return "", ""
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+		child := filepath.Join(projectRoot, entry.Name())
+		if t := DetectProjectType(child); t != "" {
+			return child, t
+		}
+	}
+	return "", ""
+}
+
 // FindProjectRoot walks up from filePath looking for known project markers.
 // Returns the first directory containing a marker, or empty string if none found.
 func FindProjectRoot(filePath string) string {
@@ -118,11 +148,15 @@ func FindProjectRoot(filePath string) string {
 
 // Verify runs verification commands for the detected project type at projectRoot.
 // It bails on the first failure to avoid wasting time.
+//
+// For multi-module monorepos where projectRoot itself has no marker but its
+// immediate children do (e.g. proxy/go.mod, app/package.json), verification
+// runs against the first matching child.
 func Verify(ctx context.Context, projectRoot string) ProjectVerification {
 	timestamp := time.Now().UTC().Format(time.RFC3339)
 	projectID := filepath.Base(projectRoot)
 
-	projectType := DetectProjectType(projectRoot)
+	verifyRoot, projectType := ResolveVerifyRoot(projectRoot)
 	if projectType == "" {
 		return ProjectVerification{
 			ProjectID: projectID,
@@ -136,7 +170,7 @@ func Verify(ctx context.Context, projectRoot string) ProjectVerification {
 	var results []Result
 
 	for _, cmdDef := range def.Commands {
-		result := runCommand(ctx, cmdDef, projectRoot)
+		result := runCommand(ctx, cmdDef, verifyRoot)
 		results = append(results, result)
 
 		if !result.Passed {

--- a/v2/internal/ai/verifier/verifier_test.go
+++ b/v2/internal/ai/verifier/verifier_test.go
@@ -81,6 +81,70 @@ func TestFindProjectRoot_NotFound(t *testing.T) {
 	}
 }
 
+func TestResolveVerifyRoot_RootMarker(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte("{}"), 0644); err != nil {
+		t.Fatalf("write marker: %v", err)
+	}
+
+	gotDir, gotType := ResolveVerifyRoot(dir)
+	if gotDir != dir {
+		t.Errorf("dir = %q, want %q", gotDir, dir)
+	}
+	if gotType != "typescript" {
+		t.Errorf("type = %q, want %q", gotType, "typescript")
+	}
+}
+
+func TestResolveVerifyRoot_MonorepoChildMarker(t *testing.T) {
+	// Mirrors the ai-collector layout: no marker at root, but proxy/go.mod
+	// and tap/go.mod live one level down. The verifier must find one of them
+	// rather than reporting verifier_unavailable.
+	root := t.TempDir()
+	proxy := filepath.Join(root, "proxy")
+	if err := os.MkdirAll(proxy, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(proxy, "go.mod"), []byte("module x\n"), 0644); err != nil {
+		t.Fatalf("write marker: %v", err)
+	}
+
+	gotDir, gotType := ResolveVerifyRoot(root)
+	if gotDir != proxy {
+		t.Errorf("dir = %q, want %q", gotDir, proxy)
+	}
+	if gotType != "go" {
+		t.Errorf("type = %q, want %q", gotType, "go")
+	}
+}
+
+func TestResolveVerifyRoot_SkipsHiddenDirs(t *testing.T) {
+	// `.git/` and similar should never be picked as a verify root, even if
+	// they happened to contain a marker file (defensive — keeps behaviour
+	// predictable).
+	root := t.TempDir()
+	hidden := filepath.Join(root, ".git")
+	if err := os.MkdirAll(hidden, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(hidden, "go.mod"), []byte("module x\n"), 0644); err != nil {
+		t.Fatalf("write marker: %v", err)
+	}
+
+	gotDir, gotType := ResolveVerifyRoot(root)
+	if gotDir != "" || gotType != "" {
+		t.Errorf("expected no resolution, got dir=%q type=%q", gotDir, gotType)
+	}
+}
+
+func TestResolveVerifyRoot_UnknownReturnsEmpty(t *testing.T) {
+	root := t.TempDir()
+	gotDir, gotType := ResolveVerifyRoot(root)
+	if gotDir != "" || gotType != "" {
+		t.Errorf("expected empty, got dir=%q type=%q", gotDir, gotType)
+	}
+}
+
 func TestVerify_UnknownProject(t *testing.T) {
 	dir := t.TempDir()
 	result := Verify(context.Background(), dir)

--- a/v2/internal/composer/service.go
+++ b/v2/internal/composer/service.go
@@ -715,7 +715,10 @@ func (s *Service) recordVerifierOutcome(decisionID, projectRoot string) {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 		defer cancel()
 
-		if verifier.DetectProjectType(projectRoot) == "" {
+		// Multi-module monorepos (e.g. ai-collector with proxy/, tap/) have no
+		// marker at root; ResolveVerifyRoot scans one level deep so we don't
+		// flag those as verifier_unavailable on every turn.
+		if _, projectType := verifier.ResolveVerifyRoot(projectRoot); projectType == "" {
 			_ = s.engineDeps.Decisions.RecordOutcome(decisionID, false, "verifier_unavailable")
 			return
 		}


### PR DESCRIPTION
## The bug

After Phase 1 wiring (#18 / #20 / #21) every Composer turn recorded:

```
phase=verifier success=0 reason="verifier_unavailable"
```

…even though the orchestrator side was working. Live data right before this fix:

| decision_id | phase | success | reason |
|---|---|---|---|
| 5bbb6875 | orchestrator | 1 | |
| 5bbb6875 | verifier | 0 | verifier_unavailable |
| bf753ca0 | orchestrator | 1 | |
| bf753ca0 | verifier | 0 | verifier_unavailable |
| 365ec40c | orchestrator | 1 | |
| 365ec40c | verifier | 0 | verifier_unavailable |

## Root cause

All 3 turns ran in `/Users/subash.karki/CZ/feature-ai-collector-macos`, a multi-module monorepo with `proxy/go.mod` and `tap/go.mod` and **no marker at root**:

```
feature-ai-collector-macos/
├── app/
├── proxy/go.mod   ← here
├── tap/go.mod     ← here
└── (no go.mod / package.json at root)
```

`verifier.DetectProjectType(root)` only checks the exact root directory. It returned `""`, so `recordVerifierOutcome` short-circuited to `verifier_unavailable` before ever running typecheck/tests.

Single-module repos like `feature-web-apps` (which has `package.json` at root) were unaffected — and would have run real verification, except no Composer turns landed on them after Phase 1 wiring shipped.

This is **Scenario B** from the diagnostic prompt — `DetectProjectType` is too narrow for monorepos. The CWD threading itself was fine.

## The fix

Add `ResolveVerifyRoot(projectRoot)` which:

1. Returns `(projectRoot, type)` if root has a marker (existing behaviour, single-module repos unchanged).
2. Otherwise scans **one level** of immediate children and returns the first child that has a marker (handles `proxy/go.mod`, `app/package.json`, etc.).
3. Skips hidden directories (`.git`, `.cache`, …) defensively.
4. Returns `("", "")` if nothing matches — same `verifier_unavailable` signal we had before.

`Verify` runs against the resolved directory. The composer caller uses the same helper for the availability gate so detection and execution stay in sync.

One level deep on purpose — vendored test fixtures buried five levels in shouldn't accidentally drive the verifier. KISS.

## Files changed

- `internal/ai/verifier/verifier.go` — new `ResolveVerifyRoot`, `Verify` uses it.
- `internal/ai/verifier/verifier_test.go` — 4 new tests (root, monorepo child, hidden-dir skip, unknown).
- `internal/composer/service.go` — gate uses `ResolveVerifyRoot` instead of `DetectProjectType`.

~50 lines fix + ~65 lines tests. No signature changes to `RecordVerifierOutcome` or any public API beyond the new helper.

## What to expect after this lands

After rebuild + relaunch, send a Composer turn and run:

```sh
sqlite3 ~/.phantom-os/phantom.db \
  "SELECT phase, success, substr(failure_reason,1,80) FROM ai_outcomes ORDER BY rowid DESC LIMIT 4;"
```

Expected: `phase=verifier` row with either:
- `success=1` and `reason="verifier_passed"` (tests pass), or
- `success=0` and a real reason like `"verifier_failed:vet exit=1 …"` (typecheck/test errors).

If still `verifier_unavailable` in a single-module or one-level monorepo, the fix didn't work and we re-diagnose.

## Repro

```go
verifier.ResolveVerifyRoot("/Users/subash.karki/CZ/feature-ai-collector-macos")
// before fix: ("", "")
// after fix:  ("…/feature-ai-collector-macos/proxy", "go")

verifier.ResolveVerifyRoot("/Users/subash.karki/CZ/feature-web-apps")
// before & after: (root, "typescript")  ← unchanged
```

## Fun fact

The Apollo guidance computer ran self-tests during coast phases the same way this verifier does — wait until the user isn't actively waiting on the system, then quietly check yourself. Buzz Aldrin reportedly trusted the AGC's self-tests more than ground control's telemetry. We are not, however, recommending you trust this verifier with anything moon-related yet.