### PR TITLE
feat(composer): record evaluator outcomes alongside verifier

### DIFF
--- a/v2/internal/ai/knowledge/decisions.go
+++ b/v2/internal/ai/knowledge/decisions.go
@@ -49,6 +49,14 @@ const PhaseOrchestrator = "orchestrator"
 // and GetFailedApproaches by default.
 const PhaseVerifier = "verifier"
 
+// PhaseEvaluator marks rows written by the response evaluator — a diagnostic
+// check that scans the assistant's text for hallucinated file paths. Kept for
+// observability and future analysis but DELIBERATELY excluded from
+// GetSuccessRate / GetFailedApproaches: a clean response (no hallucinations)
+// doesn't mean the strategy succeeded, only that the LLM didn't fabricate
+// paths. Mixing it into the verifier-driven learning signal would add noise.
+const PhaseEvaluator = "evaluator"
+
 // DecisionStore provides CRUD access to AI decisions and outcomes.
 type DecisionStore struct {
 	db *sql.DB
@@ -117,6 +125,13 @@ func (ds *DecisionStore) RecordOutcome(decisionID string, success bool, failureR
 // default — they don't represent real success, only that the picker ran.
 func (ds *DecisionStore) RecordOrchestratorOutcome(decisionID string, success bool, failureReason string) error {
 	return ds.recordOutcomeWithPhase(decisionID, success, failureReason, PhaseOrchestrator)
+}
+
+// RecordEvaluatorOutcome persists a diagnostic outcome from the response
+// evaluator (hallucinated-path scan). These rows are queryable for analysis
+// but DO NOT feed GetSuccessRate / GetFailedApproaches — see PhaseEvaluator.
+func (ds *DecisionStore) RecordEvaluatorOutcome(decisionID string, success bool, failureReason string) error {
+	return ds.recordOutcomeWithPhase(decisionID, success, failureReason, PhaseEvaluator)
 }
 
 // recordOutcomeWithPhase is the single INSERT path. Both public Record* methods

--- a/v2/internal/composer/service.go
+++ b/v2/internal/composer/service.go
@@ -29,6 +29,7 @@ import (
 	"github.com/charmbracelet/log"
 	"github.com/google/uuid"
 
+	"github.com/subashkarki/phantom-os-v2/internal/ai/evaluator"
 	"github.com/subashkarki/phantom-os-v2/internal/ai/graph/filegraph"
 	"github.com/subashkarki/phantom-os-v2/internal/ai/orchestrator"
 	"github.com/subashkarki/phantom-os-v2/internal/ai/verifier"
@@ -402,6 +403,17 @@ func (s *Service) run(ctx context.Context, cliPath string, args SendArgs, sessio
 	// Async + best-effort — must never block the next user prompt.
 	defer s.recordVerifierOutcome(decisionID, args.CWD)
 
+	// Capture the response text via pointer so the evaluator defer (registered
+	// before the run-loop builds responseText) sees the final accumulated
+	// string. Diagnostic-only — runs alongside the verifier, never gates it.
+	var responseTextRef *strings.Builder
+	defer func() {
+		if responseTextRef == nil {
+			return
+		}
+		s.recordEvaluatorOutcome(decisionID, args.CWD, responseTextRef.String())
+	}()
+
 	// First turn: --session-id <id> creates the session.
 	// Subsequent turns: --resume <id> attaches to the existing one.
 	// claude rejects --session-id reuse with "Session ID is already in use".
@@ -486,6 +498,11 @@ func (s *Service) run(ctx context.Context, cliPath string, args SendArgs, sessio
 	// composer_turns row at done/error/cancelled. Capped by maxResponseText
 	// so a runaway agent can't balloon the row past SQLite's friendly size.
 	var responseText strings.Builder
+	// Expose responseText to the evaluator defer registered above. The defer
+	// reads via pointer after the run loop completes so it sees the final
+	// accumulated text regardless of which exit path (done / error / cancel)
+	// run() takes.
+	responseTextRef = &responseText
 
 	scanner := bufio.NewScanner(stdout)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
@@ -726,6 +743,66 @@ func (s *Service) recordVerifierOutcome(decisionID, projectRoot string) {
 			log.Warn("composer: record verifier outcome", "decision_id", decisionID, "err", err)
 		}
 	}()
+}
+
+// recordEvaluatorOutcome scans the assistant's accumulated response text for
+// hallucinated file paths (paths that look like real file references but
+// don't exist on disk) and writes a diagnostic outcome to ai_outcomes
+// keyed by the orchestrator's decision ID. Spawned in a goroutine so the
+// user's next prompt never blocks on the scan.
+//
+// Runs alongside (not instead of) the verifier: the verifier produces the
+// ground-truth pass/fail signal that drives the learning loop; the evaluator
+// is observability-only — its outcomes carry phase='evaluator' and are
+// excluded from GetSuccessRate by design.
+//
+// No-ops cleanly when:
+//   - the engine isn't wired (DecisionStore == nil)
+//   - the orchestrator never recorded a decision (decisionID == "")
+//   - the turn had no project root (path-existence checks need a base dir)
+//   - the response text is empty (turn errored before producing output —
+//     skipping keeps evaluator-phase counts honest).
+func (s *Service) recordEvaluatorOutcome(decisionID, projectRoot, responseText string) {
+	if s.engineDeps.Decisions == nil || decisionID == "" || strings.TrimSpace(projectRoot) == "" {
+		return
+	}
+	if strings.TrimSpace(responseText) == "" {
+		return
+	}
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Warn("composer: evaluator panic", "decision_id", decisionID, "panic", r)
+				_ = s.engineDeps.Decisions.RecordEvaluatorOutcome(
+					decisionID, false, fmt.Sprintf("evaluator_error: %v", r),
+				)
+			}
+		}()
+
+		check := evaluator.CheckResponse(responseText, projectRoot)
+		success := !check.HasIssues
+		reason := summariseEvaluator(check)
+		if err := s.engineDeps.Decisions.RecordEvaluatorOutcome(decisionID, success, reason); err != nil {
+			log.Warn("composer: record evaluator outcome", "decision_id", decisionID, "err", err)
+		}
+	}()
+}
+
+// summariseEvaluator collapses an evaluator.ResponseCheck into a short reason
+// string. Returns empty when the response is clean (success rows don't need a
+// reason). On hallucinations, extracts the path tails from the canonical
+// "Referenced file may not exist: <path>" warning shape and joins them, so a
+// later operator can grep `failure_reason LIKE 'hallucinated:%'` to find them.
+func summariseEvaluator(check evaluator.ResponseCheck) string {
+	if !check.HasIssues || len(check.Warnings) == 0 {
+		return ""
+	}
+	const prefix = "Referenced file may not exist: "
+	paths := make([]string, 0, len(check.Warnings))
+	for _, w := range check.Warnings {
+		paths = append(paths, strings.TrimPrefix(w, prefix))
+	}
+	return "hallucinated: " + strings.Join(paths, ", ")
 }
 
 // summariseVerifier flattens the per-command verifier results into a single


### PR DESCRIPTION
## Summary

Wires the response evaluator (`internal/ai/evaluator`) into Composer's post-turn flow as a **diagnostic** signal, running alongside (not instead of) the verifier added by #18. Closes the loop on a stranded module that previously had zero callers.

After every Composer turn, a goroutine scans the assistant's accumulated response text for hallucinated file paths and writes the result to `ai_outcomes` with `phase='evaluator'`.

## Parent

Follow-up to **PR #18** (verifier wiring). Same architectural shape: a parallel post-turn goroutine, gated by the engine being wired + a real `decisionID` + a real `projectRoot`.

## Why this PR

Audit found `evaluator.CheckResponse` had **zero callers** in the codebase — the audit's claim that `internal/safety/service.go:79` invokes it turned out to be wrong (that line calls a different `evaluator` — the safety rule engine, `s.evaluator.Evaluate(ev)`). The AI response evaluator was completely stranded since it landed.

Now every Composer turn produces a third diagnostic row alongside the orchestrator's optimistic auto-record and the verifier's ground-truth pass/fail.

## Wire shape

**`internal/ai/knowledge/decisions.go`**
- New `PhaseEvaluator = "evaluator"` constant.
- New `RecordEvaluatorOutcome(decisionID, success, failureReason)` method — sibling of the existing verifier/orchestrator writers, delegating to the same `recordOutcomeWithPhase` INSERT. **No new tables, no migration** — the `phase` column added in #21 already accepts arbitrary values.

**`internal/composer/service.go`**
- New import: `internal/ai/evaluator`.
- `Service.run` registers a second `defer` next to `recordVerifierOutcome` that captures `responseText` via pointer and fires `recordEvaluatorOutcome` after the run loop finishes (works on every exit path: done, error, cancelled).
- New `recordEvaluatorOutcome` helper spawns a goroutine, calls `evaluator.CheckResponse`, summarises warnings, writes the row.
- New `summariseEvaluator` reduces `ResponseCheck` to a compact `"hallucinated: foo.go, bar.ts"` reason string for queryability (`failure_reason LIKE 'hallucinated:%'`).

## Explicit decision: NOT factored into `GetSuccessRate`

Evaluator outcomes are **observability-only**. A clean response (no hallucinated paths) does NOT mean the strategy succeeded — it only means the LLM didn't fabricate file references. Folding evaluator rows into `GetSuccessRate` would skew the auto-tune feedback loop toward "every turn was successful" and dilute the verifier-driven learning signal.

`GetSuccessRate` and `GetFailedApproaches` continue to filter to `phase = 'verifier'`. Evaluator rows are queryable directly when needed (operators, future analysis tooling, dashboards) but invisible to the learning loop.

## Edge cases handled

- **Empty response text** (turn errored before producing output) → skip the outcome row entirely. Keeps evaluator-phase counts honest — we don't want a flood of "clean" rows for turns that never produced text.
- **No project root** (NoContext mode, fresh temp dir, etc.) → skip. The evaluator's path-existence check needs a base directory.
- **Engine not wired or missing `decisionID`** → skip (same gate as verifier).
- **Evaluator panics** → recovered, logged via `slog.Warn`, an outcome row is still written with `success=false, reason="evaluator_error: <r>"` so the run never crashes and the failure is visible.

## Audit note

Audit description differed from reality in two places:

1. `ResponseCheck` does not have a `HallucinatedPaths` field — actual fields are `Warnings []string` and `HasIssues bool`. Wiring uses the actual API (`!check.HasIssues` for success, `Warnings` for the reason summary).
2. `safety/service.go:79` calls a different evaluator (the safety rule engine, not `evaluator.CheckResponse`). There was no existing caller to break.

Neither materially changed the shape of the wire — flagging for transparency.

## Manual smoke test (post-merge)

```sh
sqlite3 ~/.phantom-os/phantom.db \
  "SELECT phase, success, substr(failure_reason,1,80) FROM ai_outcomes \
   WHERE decision_id = (SELECT id FROM ai_decisions ORDER BY rowid DESC LIMIT 1) \
   ORDER BY phase;"
```

Expected after a Composer turn against a real project: three rows (`evaluator`, `orchestrator`, `verifier`). Two should show `success=1` once the parallel `fix/verifier-monorepo-detection` agent's PR lands; until then `verifier` may show `verifier_unavailable` for monorepo subprojects.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/composer/... ./internal/app/... ./internal/ai/evaluator/... ./internal/ai/knowledge/...` — all pass except 4 pre-existing trigram tests in `knowledge` (confirmed against `main` via `git stash`; not introduced by this PR)
- [ ] Post-merge: send a Composer turn that names real + fake file paths in backticks, verify the SQL above returns three phase rows with the expected success states

## Fun fact

The first malware "evaluator" was probably John von Neumann's 1949 lecture *Theory and Organization of Complicated Automata* — he formally proved a self-replicating automaton was possible, and warned that we'd one day need machines to evaluate other machines' outputs. Seventy-seven years later, here we are: writing a goroutine to grade a language model's homework, and storing the grade in SQLite.