### PR TITLE
ci: auto-build, sign, notarize, and upload macOS release asset

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,0 +1,166 @@
+# Author: Subash Karki
+# Builds the macOS Phantom app, code-signs with the Developer ID cert,
+# notarizes via Apple notarytool, then uploads the signed+notarized .zip
+# as a release asset.
+#
+# Triggers:
+#   - release.published    — fires automatically after release-please publishes a tag
+#   - workflow_dispatch    — manual run, used to back-fill releases (e.g. v0.1.9)
+#
+# Required repo secrets (already configured on karki011/phantom):
+#   APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD, APPLE_TEAM_ID
+#   APPLE_DEVELOPER_CERTIFICATE_P12_BASE64, APPLE_DEVELOPER_CERTIFICATE_PASSWORD
+
+name: Release Build
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing release tag to build and attach asset to (e.g. v0.1.9)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build, sign, notarize, upload
+    runs-on: macos-14
+    timeout-minutes: 45
+    env:
+      TAG: ${{ github.event.release.tag_name || inputs.tag }}
+
+    steps:
+      - name: Resolve tag
+        run: |
+          if [ -z "$TAG" ]; then
+            echo "::error::No tag resolved. Provide 'tag' input for workflow_dispatch."
+            exit 1
+          fi
+          # Strip leading 'v' for VERSION (Makefile expects bare semver, e.g. 0.1.9).
+          VERSION="${TAG#v}"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "Building $TAG (VERSION=$VERSION)"
+
+      - name: Checkout tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.TAG }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '25'
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Install Wails CLI
+        run: |
+          go install github.com/wailsapp/wails/v2/cmd/wails@v2.12.0
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
+      - name: Install frontend deps
+        working-directory: v2/frontend
+        run: pnpm install --frozen-lockfile
+
+      - name: Import code-signing certificate
+        env:
+          APPLE_DEVELOPER_CERTIFICATE_P12_BASE64: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_P12_BASE64 }}
+          APPLE_DEVELOPER_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_PASSWORD }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN_PATH="$RUNNER_TEMP/phantom-signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(uuidgen)"
+          CERT_PATH="$RUNNER_TEMP/cert.p12"
+
+          echo "$APPLE_DEVELOPER_CERTIFICATE_P12_BASE64" | base64 --decode > "$CERT_PATH"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERT_PATH" \
+            -P "$APPLE_DEVELOPER_CERTIFICATE_PASSWORD" \
+            -A -t cert -f pkcs12 \
+            -k "$KEYCHAIN_PATH"
+          security set-key-partition-list \
+            -S apple-tool:,apple:,codesign: \
+            -s -k "$KEYCHAIN_PASSWORD" \
+            "$KEYCHAIN_PATH" >/dev/null
+
+          # Prepend the new keychain so codesign finds the identity.
+          security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
+
+          rm -f "$CERT_PATH"
+          echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
+
+          # Sanity check: the expected identity is present.
+          security find-identity -v -p codesigning "$KEYCHAIN_PATH"
+
+      - name: Write notarization credentials
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          # Makefile expects ../.env.notarize relative to v2/ — i.e. repo root.
+          {
+            echo "APPLE_ID=$APPLE_ID"
+            echo "APPLE_APP_SPECIFIC_PASSWORD=$APPLE_APP_SPECIFIC_PASSWORD"
+            echo "APPLE_TEAM_ID=$APPLE_TEAM_ID"
+          } > .env.notarize
+          chmod 600 .env.notarize
+
+      - name: Build, sign, notarize, package
+        working-directory: v2
+        # Override VERSION so the artifact name matches the release tag — the
+        # Makefile reads v2/VERSION which can lag the release-please bump.
+        run: make release-zip VERSION="${VERSION}"
+
+      - name: Locate built artifact
+        id: artifact
+        working-directory: v2
+        run: |
+          set -euo pipefail
+          # Expected: build/dist/Phantom-<version>.zip — fall back to glob.
+          ZIP_PATH="$(ls build/dist/Phantom-*.zip 2>/dev/null | head -n1 || true)"
+          if [ -z "$ZIP_PATH" ]; then
+            echo "::error::No release zip found in v2/build/dist/"
+            ls -la build/dist || true
+            exit 1
+          fi
+          # Rename to include tag prefix for clarity, e.g. Phantom-v0.1.9.zip.
+          FINAL_NAME="Phantom-${TAG}.zip"
+          FINAL_PATH="build/dist/${FINAL_NAME}"
+          if [ "$ZIP_PATH" != "$FINAL_PATH" ]; then
+            mv "$ZIP_PATH" "$FINAL_PATH"
+          fi
+          echo "asset_path=v2/${FINAL_PATH}" >> "$GITHUB_OUTPUT"
+          echo "asset_name=${FINAL_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload asset to release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.TAG }}
+          files: ${{ steps.artifact.outputs.asset_path }}
+          fail_on_unmatched_files: true
+
+      - name: Cleanup keychain
+        if: always()
+        run: |
+          if [ -n "${KEYCHAIN_PATH:-}" ] && [ -f "$KEYCHAIN_PATH" ]; then
+            security delete-keychain "$KEYCHAIN_PATH" || true
+          fi
+          rm -f .env.notarize || true


### PR DESCRIPTION
## Why

Today the release flow is half-automated:
- release-please.yml auto-creates GitHub release tags on conventional commits (most recent: v0.1.9)
- No automated build of the actual signed + notarized macOS binary — it has to be produced locally with make release-zip and uploaded by hand

The Vercel landing page (phantom-gold-phi.vercel.app) polls GitHub Releases and currently shows Build coming soon because no asset is attached to v0.1.9. Once an asset uploads, the page flips to a download link.

## What this PR adds

A new workflow .github/workflows/release-build.yml that:

1. Triggers on release: { types: [published] } (fires automatically once release-please publishes a tag) and on workflow_dispatch with a tag input (used to back-fill v0.1.9 — see below).
2. Runs on macos-14 (real macOS for codesign + notarytool).
3. Imports the Developer ID Application certificate into a temporary keychain from a base64 secret.
4. Writes the Apple notarization creds to .env.notarize at the repo root (the path the existing Makefile already reads via -include ../.env.notarize from v2/) — no Makefile changes required.
5. Runs make release-zip VERSION="$VERSION" — the explicit VERSION override matters because v2/VERSION can lag the release-please bump (it's currently 0.1.1 while wails.json is 0.1.9).
6. Renames the artifact to Phantom-vX.Y.Z.zip and uploads it to the corresponding release via softprops/action-gh-release@v2.
7. Cleans up the temporary keychain and .env.notarize in an if: always() step.

Total: ~166 lines, single file, no Makefile or other workflow changes.

## Secrets

All required secrets are already configured in the repo (verified via gh secret list):
APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD, APPLE_TEAM_ID, APPLE_DEVELOPER_CERTIFICATE_P12_BASE64, APPLE_DEVELOPER_CERTIFICATE_PASSWORD.

## Back-filling v0.1.9

Going forward, every release-please-published tag triggers this workflow automatically. To attach an asset to the already-published v0.1.9:

1. Merge this PR.
2. Go to Actions → Release Build → Run workflow.
3. Branch: main. Tag: v0.1.9. Run.
4. ~10 min later the v0.1.9 release page (and the Vercel landing page) shows the download.

## Judgment calls

- Picked release-zip not release-dmg — smaller, faster, doesn't need brew install create-dmg in CI, and the landing page just needs an asset attached. We can add a second job for .dmg later if the UX warrants it.
- Made the workflow live at the monorepo root .github/workflows/, not v2/.github/workflows/, to match where release-please.yml lives. Both root and v2/ have separate .github/ dirs and the release event fires at the repo root.
- The Makefile's -include ../.env.notarize was the path of least resistance — writing the file from CI is one shell command and we don't have to touch the Makefile. If the file path ever moves, this workflow needs the matching update.
- Used Wails CLI v2.12.0 (pinned per the project doc) instead of @latest like ci.yml — release builds should be reproducible.

## Definition of done

- [x] Branch ci/release-build-and-upload pushed
- [x] One new file: .github/workflows/release-build.yml
- [x] Commit message: ci: add release-build workflow that builds, signs, notarizes, and uploads macOS artifact
- [x] YAML parses cleanly (ruby -ryaml)
- [x] No changes to ci.yml, release-please.yml, or the Makefile
- [ ] workflow_dispatch with tag: v0.1.9 to back-fill the existing release

## Fun fact

Apple's notarytool replaced altool in late 2021, but the protocol it speaks is still essentially CMS-detached signatures wrapped over a JSON status poll. Each notarization request gets a UUID you can look up for the next ~30 days with xcrun notarytool log <uuid> --apple-id ... — handy when the build mysteriously fails and the only signal you have is exit code 1.