### PR TITLE
feat: Composer UX overhaul — metrics, strategy viz, panels, GTM site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Phantom
 
-**A native desktop workspace for developers — terminal, editor, AI chat, git diff, and journal in one tabbed pane system.**
+**A native desktop workspace for developers — terminal, editor, composer, git diff, and journal in one tabbed pane system, backed by a local AI engine with dependency graph intelligence.**
 
 > **macOS only** (Apple Silicon + Intel). Windows and Linux are not supported today. See [Platform support](#platform-support).
 
@@ -10,27 +10,29 @@ Built by [Subash Karki](https://github.com/karki011)
 
 ## What it is
 
-Phantom collapses your terminal, code editor, AI chat, git diff viewer, journal, and markdown preview into a single tabbed pane system — so you stop alt-tabbing between iTerm, VS Code, ChatGPT, and your git client and just work in one place. It's built on Wails (Go + SolidJS) for native performance, watches your filesystem in real time, routes every git call through a hardened wrapper to keep state sane, and ships with a first-class AI engine that's hook-aware and MCP-channel-ready — meaning the AI can see what you're editing, what changed, and what you ran, then act on it.
+Phantom collapses your terminal, code editor, AI composer, git diff viewer, journal, and markdown preview into a single tabbed pane system — so you stop alt-tabbing between iTerm, VS Code, ChatGPT, and your git client and just work in one place. It's built on Wails (Go + SolidJS) for native performance, watches your filesystem in real time, routes every git call through a hardened wrapper to keep state sane, and ships with a first-class AI engine that's hook-aware and MCP-channel-ready — meaning the AI can see what you're editing, what changed, and what you ran, then act on it.
 
 ## Status
 
 - **Platform:** macOS only (Apple Silicon + Intel — universal binary)
-- **Version:** 0.1.1 — pre-release, public preview
+- **Version:** 0.1.9
 - **Distribution:** Signed with Apple Developer ID + notarized + stapled (no Gatekeeper prompts)
 
 ## Platform support
 
 | OS | Status | Why |
 |---|---|---|
-| **macOS** (Apple Silicon + Intel) | ✅ Supported | Primary target. Universal binary, signed + notarized. |
-| **Windows** | ❌ Not supported | No build target, no installer, untested. Wails *can* target Windows via WebView2 — contributors welcome. |
-| **Linux** | ❌ Not supported | No build target, untested. Wails *can* target Linux via WebKitGTK — contributors welcome. |
+| **macOS** (Apple Silicon + Intel) | Supported | Primary target. Universal binary, signed + notarized. |
+| **Windows** | Not supported | No build target, no installer, untested. Wails *can* target Windows via WebView2 — contributors welcome. |
+| **Linux** | Not supported | No build target, untested. Wails *can* target Linux via WebKitGTK — contributors welcome. |
 
-Phantom is built for macOS first because the AI engine, file watcher, audio cues, and shell integration are all tuned to macOS conventions (`~/Library/`, AVFoundation, etc.). Cross-platform support isn't on the near-term roadmap. If you need Windows or Linux, open an issue or send a PR — but treat both as greenfield work.
+Phantom is built for macOS first because the AI engine, file watcher, audio cues, Keychain integration, and shell integration are all tuned to macOS conventions (`~/Library/`, AVFoundation, Security framework, etc.). Cross-platform support isn't on the near-term roadmap. If you need Windows or Linux, open an issue or send a PR — but treat both as greenfield work.
+
+---
 
 ## Install (prebuilt)
 
-1. Download `Phantom-0.1.1.zip` from [Releases](https://github.com/karki011/phantom/releases)
+1. Download `Phantom-latest.zip` from [Releases](https://github.com/karki011/phantom/releases)
 2. Unzip and drag `Phantom.app` to `/Applications`
 3. Double-click — no first-launch internet required (notarization is stapled)
 
@@ -45,7 +47,7 @@ Phantom is built for macOS first because the AI engine, file watcher, audio cues
 - [Wails CLI](https://wails.io/) — `go install github.com/wailsapp/wails/v2/cmd/wails@latest`
 - [Node.js](https://nodejs.org/) 22+ and [pnpm](https://pnpm.io/) 10+
 
-### Dev
+### Development
 
 ```bash
 cd v2
@@ -56,33 +58,147 @@ wails dev      # or: make dev
 
 ```bash
 cd v2
-make release-zip
+make release-zip   # signed + notarized zip
+make release       # signed + notarized DMG (requires `brew install create-dmg`)
 ```
 
 Apple notarization credentials are loaded from `phantom-os/.env.notarize` (gitignored — see `.env.notarize.example`).
 
+### Authentication
+
+Phantom supports two authentication modes. All local features (AI engine, graph, hooks, MCP, safety) work with both.
+
+| Mode | Setup | Billing |
+|---|---|---|
+| **Claude Subscription** (Max/Pro/Enterprise) | `claude login` — zero config | Included in subscription |
+| **BYOK API Key** | Settings > AI Provider > enter key | Per-token via Anthropic API |
+
+BYOK keys are stored in the macOS Keychain and never logged to disk.
+
+---
+
 ## Features
 
-| Pane | What it does |
-|---|---|
-| **Terminal** | Full PTY with shell integration |
-| **TUI** | Interactive TUI apps (vim, lazygit, etc.) |
-| **Editor** | Monaco-based code editor with diff support |
-| **Chat** | AI chat with code-aware context injection |
-| **Diff** | Live git diff viewer |
-| **Home** | Workspace dashboard and quick launch |
-| **Journal** | Per-project journaling |
-| **Markdown preview** | Side-by-side rendered markdown |
+### Composer
 
-Plus: real-time filesystem watching (fsnotify), per-pane state persistence, custom audio engine for ambient feedback, AI engine with MCP channels for tool integration, and a hook system that lets the AI act on file changes and shell commands.
+Full agentic coding pane powered by Claude CLI with stream-json output.
+
+- **Markdown rendering** — headings, code blocks with syntax highlighting, lists, tables, links, blockquotes
+- **Session cost meter** — running dollar total per session
+- **Context window gauge** — color-coded progress bar (accent/warning/danger thresholds)
+- **Turn efficiency cards** — duration, tokens in/out, cost, files edited, lines changed per turn
+- **Auto-accept toggle** — persisted preference, auto-marks edit cards as accepted
+- **ASSISTANT/YOU badges** with turn dividers between conversation turns
+- **Edit card review** — accept/discard per-file with inline diff viewer
+- **Model picker** — Sonnet 4.6 / Opus / Haiku
+- **Effort level control** — Auto / Low / Medium / High / Max
+- **Strategy visualization** — shows the orchestrator's strategy name, confidence, complexity, risk, blast radius
+- **Tool call status dots** — blinking = in-progress, green = success, red = error
+- **Thinking blocks** — collapsed by default, click to expand
+- **Memory viewer panel** — right rail showing loaded CLAUDE.md, project rules
+- **Skill browser panel** — right rail listing `.claude/skills/` with search and invoke
+- **Hook event visibility** — `--include-hook-events` passed to CLI
+- **Past sessions sidebar** — resume, context menu, delete
+- **Drag and drop file mentions** + image paste
+- **No-context mode toggle**
+- **Session persistence** across app restarts
+
+### AI Engine
+
+Local Go-based reasoning engine with dependency graph intelligence. Runs entirely on-device — no cloud calls for engine logic.
+
+- **7+ reasoning strategies:** Direct, Decompose, Advisor, SelfRefine, TreeOfThought, Debate, GraphOfThought
+- **Orchestrator pipeline:** assess > graph context > blast radius > select strategy > decide > verify > learn
+- **Dependency graph intelligence** — file-level graph with blast radius analysis, related file discovery, shortest path queries
+- **Auto-tune** — EMA-smoothed threshold recalibration based on observed outcomes
+- **Decision learning** — per-project SQLite storage, cross-project `GlobalPatternStore`
+- **Hallucination detection** — verifies file paths referenced in AI responses actually exist on disk
+- **Gap detector** — identifies missing context before the AI acts
+- **Penalty system** — tracks repeated failures to avoid known-bad approaches
+- **Context injector** — enriches prompts with graph context automatically
+- **Multi-language support** — parsers for TypeScript/JavaScript, Python, Go, Rust, Java
+
+### Safety and Security
+
+- **Ward rules engine** — YAML-based guardrails in `~/.phantom-os/wards/` (block patterns, require patterns, file scope filters)
+- **PII scanner** — detects emails, API keys, AWS keys, passwords, tokens before they leave the machine
+- **Edit gate hook** — blocks Write/Edit/MultiEdit tool calls when enabled via preferences
+- **Audit logging** — `ward_audit` SQLite table for all rule evaluations
+- **BYOK key storage** — macOS Keychain via Security framework (never written to disk or logs)
+
+### Desktop Workspace
+
+- **Terminal** — full PTY via xterm.js 6.0 with 497 themes, OSC 633 shell integration, Quick-Fix on errors, sticky scroll, jump-to-prompt, Cmd+P command history palette, persistent sessions (hot + cold restore), addon-serialize PTY snapshots, tab auto-rename via OSC 0/1/2
+- **Editor** — Monaco-based code editor with diff support, workspace tsconfig + @types loaded for real type checking
+- **Diff** — live git diff viewer with folding, inline editing, and save
+- **Composer** — agentic coding pane (see above)
+- **Journal** — per-project journaling with date pagination, AI-generated daily digest
+- **Home** — workspace dashboard with project cards, graph stats, quick launch grid, git status, PR/CI badges
+- **File browser** — tree view with search, drag-to-mention, create file/folder, context menus
+- **Git workflow** — branch switcher, push/pull with feedback, discard, stash, undo commit, PR creation, worktree management
+- **Split panes** — up to 6 per tab
+- **Custom audio engine** — ambient feedback sounds, boot/shutdown ceremonies, configurable sound styles
+- **System metrics** — live CPU and memory in the header bar, process breakdown popover
+- **Onboarding** — 4-phase boot sequence (operator ID, display calibration, audio setup, AI consent) with particle burst animation
+
+### Hook System and MCP
+
+- **6 auto-registered hooks:** prompt-enricher, edit-gate, outcome-capture, feedback-detector, async-analyzer, file-changed
+- **MCP server (`phantom-ai`)** with 10+ tools:
+  - `phantom_before_edit` — pre-edit context + blast radius + strategy (one call does it all)
+  - `phantom_graph_context` — file dependency deep-dive
+  - `phantom_graph_blast_radius` — what breaks if a file changes
+  - `phantom_graph_related` — find all files involved in a feature
+  - `phantom_graph_stats` — graph coverage statistics
+  - `phantom_graph_path` — shortest dependency path between two files
+  - `phantom_orchestrator_process` — route goals through the strategy pipeline
+  - `phantom_orchestrator_history` — learn from past decisions
+  - `phantom_evaluate_output` — verify AI output quality
+  - `phantom_list_projects` — enumerate tracked projects
+- **Auto-registration** in `~/.mcp.json` and `~/.claude/settings.json`
+- **Hook events visible** in Composer via `--include-hook-events`
+
+### Gamification
+
+- **XP system** with 6 stat categories: Intelligence, Strength, Sense, Vitality, Agility, Perception
+- **Achievements** and **daily quests**
+- **Streaks** — consecutive day tracking
+- **Rank progression** with level thresholds
+- **Hunter profile** — stats dashboard on the home screen
+- **Cockpit view** — analytics dashboard with XP bar, skill usage, session metrics
+
+### Multi-Provider Support
+
+Config-driven provider architecture supporting multiple AI CLIs.
+
+| Provider | Status | Notes |
+|---|---|---|
+| **Claude Code** | Full support | Primary target — sessions, streaming, conversation parsing, cost tracking |
+| **OpenAI Codex** | Supported | SQLite + JSONL session discovery, event schema parsing |
+| **Gemini** | Config-ready | YAML config; adapter pending |
+
+Provider configs are 3-tier: embedded defaults > user overrides (`~/.phantom-os/providers/`) > custom providers (`~/.phantom-os/providers/custom/`).
+
+---
 
 ## Architecture
 
 Three-layer split:
 
-- **Go backend** (`v2/internal/`) — git operations, file watching, AI engine, SQLite persistence
-- **Wails bindings** — type-safe RPC between Go and the frontend
-- **SolidJS frontend** (`v2/frontend/src/`) — reactive UI, pane orchestration, vanilla-extract styling
+```
+┌─────────────────────────────────────────┐
+│  SolidJS Frontend (frontend/src/)       │
+│  Reactive UI, pane orchestration,       │
+│  vanilla-extract styling                │
+├─────────────────────────────────────────┤
+│  Wails Bindings                         │
+│  Type-safe RPC between Go and frontend  │
+├─────────────────────────────────────────┤
+│  Go Backend (internal/)                 │
+│  Git ops, file watching, AI engine,     │
+│  MCP server, SQLite, providers          │
+└─────────────────────────────────────────┘
+```
 
 ## Tech stack
 
@@ -93,9 +209,12 @@ Three-layer split:
 | Frontend | [SolidJS](https://www.solidjs.com/) + TypeScript |
 | Styling | [vanilla-extract](https://vanilla-extract.style/) (typed CSS modules) |
 | Database | SQLite via [sqlc](https://sqlc.dev/) |
-| Editor | Monaco |
-| File watching | fsnotify |
-| AI integration | MCP (Model Context Protocol) channels + hook system |
+| Terminal | [xterm.js](https://xtermjs.org/) 6.0 (497 themes) |
+| Editor | [Monaco](https://microsoft.github.io/monaco-editor/) |
+| File watching | [fsnotify](https://github.com/fsnotify/fsnotify) |
+| AI integration | MCP (Model Context Protocol) + hook system |
+| State management | [Jotai](https://jotai.org/) |
+| UI primitives | [Kobalte](https://kobalte.dev/) |
 
 ## Project layout
 
@@ -103,12 +222,41 @@ Three-layer split:
 phantom-os/
 ├── v2/                     # Active codebase (this is the app)
 │   ├── internal/           # Go backend
+│   │   ├── ai/            #   AI engine (strategies, orchestrator, graph, learning)
+│   │   ├── chat/           #   Chat service (Claude CLI streaming)
+│   │   ├── collector/      #   Session/task/todo watchers
+│   │   ├── db/             #   SQLite schemas + sqlc queries
+│   │   ├── git/            #   Git operations (hardened wrapper)
+│   │   ├── mcp/            #   MCP server (phantom-ai tools)
+│   │   ├── provider/       #   Multi-provider system (Claude, Codex, Gemini)
+│   │   ├── stream/         #   JSONL streaming + event parsing
+│   │   ├── terminal/       #   PTY management
+│   │   └── ward/           #   Safety rules engine
 │   ├── frontend/           # SolidJS frontend
+│   │   └── src/
+│   │       ├── components/ #   UI components (panes, sidebar, composer, etc.)
+│   │       ├── core/       #   Audio, editor, bindings, branding
+│   │       └── styles/     #   vanilla-extract theme + recipes
+│   ├── configs/            # Provider config TOMLs/YAMLs
+│   ├── docs/               # Design docs, plans, research
 │   ├── build/              # Build artifacts + macOS plist/entitlements
 │   └── Makefile            # dev / release / signing targets
+├── docs/                   # Landing page + release setup
 ├── .env.notarize.example   # Apple notarization template
-└── .gitignore
+└── CHANGELOG.md            # Auto-generated from conventional commits
 ```
+
+## For agents
+
+If you are an LLM/coding agent loading this repo, start with **`v2/llms-full.txt`** at the repo root. It is a single-file digest of the curated docs (README, AI engine, config-driven architecture, plans) and is sized to fit in a single context window.
+
+Regenerate it after doc changes:
+
+```bash
+cd v2 && make docs-llm
+```
+
+---
 
 ## Contributing
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>PhantomOS — Developer Desktop Environment</title>
-  <meta name="description" content="PhantomOS is a developer desktop environment built with Electron. Manage git worktrees, terminal sessions, AI-powered code assistance, and project orchestration in one unified workspace.">
+  <meta name="description" content="Phantom is a developer desktop environment built with Wails (Go + SolidJS). Manage git worktrees, terminal sessions, AI-powered code assistance, and project orchestration in one unified workspace.">
   <meta name="theme-color" content="#0a0a0f">
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cdefs%3E%3CradialGradient id='bg' cx='50%25' cy='50%25' r='50%25'%3E%3Cstop offset='0%25' stop-color='%23111128'/%3E%3Cstop offset='100%25' stop-color='%230a0a14'/%3E%3C/radialGradient%3E%3C/defs%3E%3Ccircle cx='256' cy='256' r='248' fill='url(%23bg)'/%3E%3Ccircle cx='256' cy='256' r='244' fill='none' stroke='%2300d4ff' stroke-width='1.5' opacity='0.15'/%3E%3Cg stroke='%2300d4ff' stroke-width='3' opacity='0.5'%3E%3Cline x1='256' y1='52' x2='340' y2='68'/%3E%3Cline x1='340' y1='68' x2='404' y2='116'/%3E%3Cline x1='404' y1='116' x2='420' y2='196'/%3E%3Cline x1='420' y1='196' x2='420' y2='276'/%3E%3Cline x1='420' y1='276' x2='420' y2='356'/%3E%3Cline x1='420' y1='356' x2='388' y2='404'/%3E%3Cline x1='388' y1='404' x2='348' y2='440'/%3E%3Cline x1='348' y1='440' x2='308' y2='404'/%3E%3Cline x1='308' y1='404' x2='256' y2='440'/%3E%3Cline x1='256' y1='440' x2='204' y2='404'/%3E%3Cline x1='204' y1='404' x2='164' y2='440'/%3E%3Cline x1='164' y1='440' x2='124' y2='404'/%3E%3Cline x1='124' y1='404' x2='92' y2='356'/%3E%3Cline x1='92' y1='356' x2='92' y2='276'/%3E%3Cline x1='92' y1='276' x2='92' y2='196'/%3E%3Cline x1='92' y1='196' x2='108' y2='116'/%3E%3Cline x1='108' y1='116' x2='172' y2='68'/%3E%3Cline x1='172' y1='68' x2='256' y2='52'/%3E%3C/g%3E%3Cg fill='%2300d4ff' opacity='0.6'%3E%3Ccircle cx='256' cy='52' r='7'/%3E%3Ccircle cx='340' cy='68' r='7'/%3E%3Ccircle cx='404' cy='116' r='7'/%3E%3Ccircle cx='420' cy='196' r='7'/%3E%3Ccircle cx='420' cy='276' r='7'/%3E%3Ccircle cx='420' cy='356' r='7'/%3E%3Ccircle cx='388' cy='404' r='7'/%3E%3Ccircle cx='348' cy='440' r='7'/%3E%3Ccircle cx='308' cy='404' r='7'/%3E%3Ccircle cx='256' cy='440' r='7'/%3E%3Ccircle cx='204' cy='404' r='7'/%3E%3Ccircle cx='164' cy='440' r='7'/%3E%3Ccircle cx='124' cy='404' r='7'/%3E%3Ccircle cx='92' cy='356' r='7'/%3E%3Ccircle cx='92' cy='276' r='7'/%3E%3Ccircle cx='92' cy='196' r='7'/%3E%3Ccircle cx='108' cy='116' r='7'/%3E%3Ccircle cx='172' cy='68' r='7'/%3E%3C/g%3E%3Ccircle cx='192' cy='212' r='18' fill='%23a855f7'/%3E%3Ccircle cx='320' cy='212' r='18' fill='%23a855f7'/%3E%3Ccircle cx='192' cy='212' r='8' fill='%23c084fc' opacity='0.7'/%3E%3Ccircle cx='320' cy='212' r='8' fill='%23c084fc' opacity='0.7'/%3E%3C/svg%3E">
   <style>
@@ -654,7 +654,7 @@
           Your dev environment,<br><span class="gradient-text">reimagined.</span>
         </h1>
         <p class="hero-subtitle animate-in animate-in-delay-2">
-          PhantomOS is a developer desktop environment built with Electron.
+          Phantom is a developer desktop environment built with Wails (Go + SolidJS).
           Manage git worktrees, terminal sessions, AI-powered code assistance,
           and project orchestration — all in one unified workspace.
         </p>

--- a/v2/README.md
+++ b/v2/README.md
@@ -1,6 +1,6 @@
-# Phantom
+# Phantom (v2)
 
-Phantom is a Wails-based desktop app for managing AI coding sessions across multiple providers (Claude Code, Codex, etc.) with a config-driven provider architecture.
+Phantom is a Wails-based desktop app for managing AI coding sessions across multiple providers (Claude Code, Codex, etc.) with a config-driven provider architecture and a local AI reasoning engine.
 
 ## How this was built
 
@@ -12,10 +12,15 @@ Trade-off worth naming: rapid iteration and opinionated defaults, with the occas
 
 ## Highlights
 
-- **Composer** — agentic edit pane with Accept/Discard cards, past-session sidebar, and right-click actions. Default model is Opus.
-- **Terminal shell integration** — OSC 633 marks, Quick-Fix on errors, sticky scroll, jump-to-prompt, and a Cmd+P palette over command history.
-- **Workspace Ship-It** — merge button + reviewer chips on the Workspace card; sidebar shows a `±N` dirty-files badge per worktree.
-- **BYOK** — store your own Anthropic API key in the macOS Keychain via Settings → AI Provider; fall back to the Claude subscription anytime.
+- **Composer** — full agentic coding pane with Claude CLI stream-json output, markdown rendering (headings, code blocks, lists, tables, links, blockquotes), session cost meter, context window gauge (color-coded accent/warning/danger), turn efficiency cards (duration, tokens, cost, files edited, lines changed), auto-accept toggle, ASSISTANT/YOU badges with turn dividers, edit card review (accept/discard per-file with inline diff), model picker (Sonnet 4.6/Opus/Haiku), effort level control (Auto/Low/Medium/High/Max), strategy visualization (name, confidence, complexity, risk, blast radius), tool call status dots (blinking/green/red), thinking blocks (collapsed, expandable), memory viewer panel, skill browser panel, hook event visibility, past sessions sidebar (resume/delete), drag-and-drop file mentions + image paste, no-context mode toggle, session persistence across restarts.
+- **AI Engine** — 7+ local reasoning strategies (Direct, Decompose, Advisor, SelfRefine, TreeOfThought, Debate, GraphOfThought), orchestrator pipeline (assess > graph context > blast radius > select strategy > decide > verify > learn), dependency graph intelligence with blast radius analysis, auto-tune (EMA-smoothed), decision learning (per-project + cross-project GlobalPatternStore), hallucination detection, gap detector, penalty system, context injector.
+- **Safety** — Ward rules engine (YAML guardrails in `~/.phantom-os/wards/`), PII scanner (emails, API keys, AWS keys, passwords, tokens), edit gate hook (blocks Write/Edit/MultiEdit), audit logging (ward_audit SQLite table), BYOK key in macOS Keychain.
+- **Terminal** — xterm.js 6.0 with 497 themes, OSC 633 shell integration, Quick-Fix on errors, sticky scroll, jump-to-prompt, Cmd+P command history palette, persistent sessions (hot + cold restore), PTY snapshot via addon-serialize, tab auto-rename via OSC 0/1/2.
+- **Workspace** — Monaco editor with workspace type checking, live git diff viewer, file browser with drag-to-mention, branch switcher, push/pull/discard/stash/undo, PR creation with reviewer chips, worktree management with dirty-files badge, split panes (up to 6), journal with daily digest, custom audio engine, system metrics (CPU/memory), boot/shutdown ceremonies.
+- **Hook System** — 6 auto-registered hooks (prompt-enricher, edit-gate, outcome-capture, feedback-detector, async-analyzer, file-changed). MCP server (phantom-ai) with 10+ tools for graph context, blast radius, strategy routing. Auto-registration in `~/.mcp.json` and `~/.claude/settings.json`.
+- **Gamification** — XP system with 6 stat categories (Intelligence, Strength, Sense, Vitality, Agility, Perception), achievements, daily quests, streaks, rank progression, hunter profile, cockpit analytics dashboard.
+- **BYOK** — store your own Anthropic API key in the macOS Keychain via Settings > AI Provider; fall back to the Claude subscription anytime.
+- **Multi-provider** — config-driven provider architecture supporting Claude, Codex, and Gemini. 3-tier config loading: embedded defaults > user overrides > custom providers.
 - **Persistent terminals** — addon-serialize PTY snapshot + tab auto-rename via OSC 0/1/2 keep sessions where you left them.
 
 ## Quick start
@@ -30,10 +35,10 @@ Open Composer from the QuickLaunch grid (or hit Cmd+I to focus the prompt compos
 ## Repository layout
 
 - `cmd/` — Go entrypoints (Wails app, standalone MCP binary).
-- `internal/` — Go backend: providers, app bindings, db (sqlc), git, terminal, tui.
+- `internal/` — Go backend: AI engine, providers, app bindings, db (sqlc), git, terminal, tui, MCP, wards, collectors, streaming.
 - `frontend/` — SolidJS + Vanilla Extract + Kobalte UI.
+- `configs/` — provider config TOMLs/YAMLs.
 - `docs/` — design docs, plans, research notes.
-- `configs/` — provider config TOMLs.
 
 ## For agents
 
@@ -49,7 +54,8 @@ The file is committed to the repo so it can be fetched directly via raw URL.
 
 ## Authoritative docs
 
-- `docs/ai-engine.md` — Phantom AI engine (graph, blast radius, orchestrator).
-- `docs/DESIGN-config-driven-architecture.md` — provider abstraction.
+- `docs/ai-engine.md` — Phantom AI engine (graph, blast radius, orchestrator, providers, streaming).
+- `docs/DESIGN-config-driven-architecture.md` — provider abstraction and 3-tier config loading.
 - `docs/PLAN-home-redesign.md` — home screen redesign plan.
 - `docs/PLAN-phase-1-upgrades.md` — current phase 1 PR plan.
+- `UPGRADE_ROADMAP.md` — 16-item upgrade roadmap (3 phases).

--- a/v2/frontend/src/components/panes/ComposerMemoryPanel.css.ts
+++ b/v2/frontend/src/components/panes/ComposerMemoryPanel.css.ts
@@ -1,0 +1,128 @@
+// Author: Subash Karki
+import { style } from '@vanilla-extract/css';
+import { vars } from '@/styles/theme.css';
+
+export const panel = style({
+  display: 'flex',
+  flexDirection: 'column',
+  width: 320,
+  flex: '0 0 320px',
+  borderLeft: `1px solid ${vars.color.divider}`,
+  background: vars.color.bgSecondary,
+  overflow: 'hidden',
+});
+
+export const panelHeader = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: vars.space.sm,
+  padding: `${vars.space.sm} ${vars.space.md}`,
+  borderBottom: `1px solid ${vars.color.divider}`,
+});
+
+export const panelTitle = style({
+  fontWeight: 600,
+  fontSize: vars.fontSize.xs,
+  color: vars.color.textPrimary,
+});
+
+export const panelSize = style({
+  flex: 1,
+  fontSize: '10px',
+  fontFamily: vars.font.mono,
+  color: vars.color.textDisabled,
+  textAlign: 'right',
+});
+
+export const panelClose = style({
+  background: 'transparent',
+  border: 'none',
+  color: vars.color.textDisabled,
+  cursor: 'pointer',
+  padding: '2px',
+  fontSize: vars.fontSize.xs,
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  borderRadius: vars.radius.sm,
+  ':hover': {
+    color: vars.color.textPrimary,
+    background: vars.color.bgHover,
+  },
+});
+
+export const panelBody = style({
+  flex: 1,
+  overflowY: 'auto',
+  padding: vars.space.sm,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.space.xs,
+});
+
+export const panelEmpty = style({
+  padding: vars.space.lg,
+  textAlign: 'center',
+  fontStyle: 'italic',
+  color: vars.color.textDisabled,
+  fontSize: vars.fontSize.xs,
+});
+
+export const memoryItem = style({
+  borderRadius: vars.radius.sm,
+  border: `1px solid ${vars.color.border}`,
+  overflow: 'hidden',
+});
+
+export const memoryItemHeader = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: vars.space.xs,
+  padding: `${vars.space.xs} ${vars.space.sm}`,
+  cursor: 'pointer',
+  fontSize: vars.fontSize.xs,
+  color: vars.color.textSecondary,
+  ':hover': {
+    background: vars.color.bgHover,
+  },
+});
+
+export const memoryItemName = style({
+  flex: 1,
+  fontFamily: vars.font.mono,
+  color: vars.color.textPrimary,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+});
+
+export const memoryItemLevel = style({
+  padding: '1px 5px',
+  borderRadius: vars.radius.sm,
+  background: vars.color.bgTertiary,
+  fontSize: '9px',
+  fontWeight: 600,
+  letterSpacing: '0.05em',
+  textTransform: 'uppercase',
+  color: vars.color.textDisabled,
+});
+
+export const memoryItemSize = style({
+  fontFamily: vars.font.mono,
+  fontSize: '10px',
+  color: vars.color.textDisabled,
+});
+
+export const memoryItemContent = style({
+  padding: vars.space.sm,
+  background: vars.color.bgTertiary,
+  fontSize: '10px',
+  fontFamily: vars.font.mono,
+  color: vars.color.textSecondary,
+  whiteSpace: 'pre-wrap',
+  wordBreak: 'break-word',
+  maxHeight: 200,
+  overflowY: 'auto',
+  borderTop: `1px solid ${vars.color.border}`,
+  margin: 0,
+});

--- a/v2/frontend/src/components/panes/ComposerMemoryPanel.tsx
+++ b/v2/frontend/src/components/panes/ComposerMemoryPanel.tsx
@@ -1,0 +1,89 @@
+// Author: Subash Karki
+import { createSignal, onMount, For, Show } from 'solid-js';
+import { ChevronRight, ChevronDown, FileText, Globe, BookOpen, X } from 'lucide-solid';
+import { composerGetMemoryContext, type MemoryContextItem } from '@/core/bindings/composer';
+import * as styles from './ComposerMemoryPanel.css';
+
+interface MemoryPanelProps {
+  cwd: string;
+  onClose: () => void;
+}
+
+export default function ComposerMemoryPanel(props: MemoryPanelProps) {
+  const [items, setItems] = createSignal<MemoryContextItem[]>([]);
+  const [expandedPaths, setExpandedPaths] = createSignal<Set<string>>(new Set());
+
+  onMount(async () => {
+    const ctx = await composerGetMemoryContext(props.cwd);
+    setItems(ctx);
+  });
+
+  const toggleExpand = (path: string) => {
+    setExpandedPaths((prev) => {
+      const next = new Set(prev);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
+      return next;
+    });
+  };
+
+  const isExpanded = (path: string) => expandedPaths().has(path);
+
+  const totalSize = () => items().reduce((sum, i) => sum + i.size, 0);
+
+  const formatSize = (bytes: number) => {
+    if (bytes >= 1024) return `${(bytes / 1024).toFixed(1)}KB`;
+    return `${bytes}B`;
+  };
+
+  const iconForLevel = (level: string) => {
+    switch (level) {
+      case 'global':
+        return <Globe size={12} />;
+      case 'rule':
+        return <BookOpen size={12} />;
+      default:
+        return <FileText size={12} />;
+    }
+  };
+
+  const basename = (path: string) => {
+    const idx = path.lastIndexOf('/');
+    return idx >= 0 ? path.slice(idx + 1) : path;
+  };
+
+  return (
+    <div class={styles.panel}>
+      <div class={styles.panelHeader}>
+        <span class={styles.panelTitle}>Memory Context</span>
+        <span class={styles.panelSize}>{formatSize(totalSize())} loaded</span>
+        <button class={styles.panelClose} type="button" onClick={props.onClose}>
+          <X size={12} />
+        </button>
+      </div>
+      <div class={styles.panelBody}>
+        <Show when={items().length === 0}>
+          <div class={styles.panelEmpty}>No context files found</div>
+        </Show>
+        <For each={items()}>
+          {(item) => (
+            <div class={styles.memoryItem}>
+              <div class={styles.memoryItemHeader} onClick={() => toggleExpand(item.path)}>
+                {iconForLevel(item.level)}
+                <Show when={isExpanded(item.path)} fallback={<ChevronRight size={11} />}>
+                  <ChevronDown size={11} />
+                </Show>
+                <span class={styles.memoryItemName}>{basename(item.path)}</span>
+                <span class={styles.memoryItemLevel}>{item.level}</span>
+                <span class={styles.memoryItemSize}>{formatSize(item.size)}</span>
+              </div>
+              <Show when={isExpanded(item.path)}>
+                <pre class={styles.memoryItemContent}>{item.content}</pre>
+              </Show>
+            </div>
+          )}
+        </For>
+      </div>
+    </div>
+  );
+}

--- a/v2/frontend/src/components/panes/ComposerMetrics.css.ts
+++ b/v2/frontend/src/components/panes/ComposerMetrics.css.ts
@@ -1,0 +1,82 @@
+// Author: Subash Karki
+import { style } from '@vanilla-extract/css';
+import { vars } from '@/styles/theme.css';
+
+export const metricsSeparator = style({
+  color: vars.color.textDisabled,
+  margin: `0 ${vars.space.xs}`,
+});
+
+export const metricsGroup = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: vars.space.xs,
+});
+
+export const metricsDot = style({
+  color: vars.color.textDisabled,
+});
+
+export const sessionTotal = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: vars.space.xs,
+  fontFamily: vars.font.mono,
+  color: vars.color.accent,
+  fontWeight: 600,
+});
+
+export const contextGauge = style({
+  position: 'relative',
+  height: 3,
+  background: vars.color.bgTertiary,
+  overflow: 'hidden',
+  cursor: 'default',
+  vars: {
+    '--gauge-color-accent': vars.color.accent,
+    '--gauge-color-warning': vars.color.warning,
+    '--gauge-color-danger': vars.color.danger,
+  },
+});
+
+export const contextGaugeFill = style({
+  height: '100%',
+  transition: 'width 300ms ease, background 300ms ease',
+});
+
+export const contextGaugeLabel = style({
+  position: 'absolute',
+  right: vars.space.sm,
+  top: '50%',
+  transform: 'translateY(-50%)',
+  fontSize: '9px',
+  fontFamily: vars.font.mono,
+  color: vars.color.textDisabled,
+  opacity: 0,
+  transition: 'opacity 150ms ease',
+  selectors: {
+    [`${contextGauge}:hover &`]: { opacity: 1 },
+  },
+});
+
+export const turnMetrics = style({
+  display: 'flex',
+  alignItems: 'center',
+  flexWrap: 'wrap',
+  gap: vars.space.xs,
+  padding: `${vars.space.xs} ${vars.space.sm}`,
+  borderRadius: vars.radius.sm,
+  background: vars.color.bgSecondary,
+  border: `1px solid ${vars.color.border}`,
+  fontFamily: vars.font.mono,
+  fontSize: '10px',
+  color: vars.color.textDisabled,
+});
+
+export const turnLinesAdded = style({
+  color: vars.color.success,
+});
+
+export const turnLinesRemoved = style({
+  color: vars.color.danger,
+});

--- a/v2/frontend/src/components/panes/ComposerPane.css.ts
+++ b/v2/frontend/src/components/panes/ComposerPane.css.ts
@@ -28,7 +28,7 @@ export const statusStrip = style({
   display: 'flex',
   alignItems: 'center',
   gap: vars.space.sm,
-  padding: `${vars.space.sm} ${vars.space.lg}`,
+  padding: `${vars.space.sm} ${vars.space.xxl}`,
   borderBottom: `1px solid ${vars.color.divider}`,
   background: vars.color.bgSecondary,
   fontSize: vars.fontSize.xs,
@@ -67,7 +67,7 @@ export const cancelBtn = style({
 export const feed = style({
   flex: 1,
   overflowY: 'auto',
-  padding: `${vars.space.lg} ${vars.space.xl}`,
+  padding: `${vars.space.lg} ${vars.space.xxl}`,
   display: 'flex',
   flexDirection: 'column',
   gap: vars.space.lg,
@@ -95,8 +95,8 @@ export const userTurn = style({
 export const assistantText = style({
   fontSize: vars.fontSize.sm,
   color: vars.color.textPrimary,
-  whiteSpace: 'pre-wrap',
   wordBreak: 'break-word',
+  lineHeight: 1.6,
 });
 
 export const editCard = style({
@@ -132,24 +132,42 @@ export const editBtn = style({
   background: 'transparent',
   border: `1px solid ${vars.color.border}`,
   color: vars.color.textSecondary,
-  padding: '2px 8px',
+  padding: '3px 10px',
   borderRadius: vars.radius.sm,
   cursor: 'pointer',
   fontSize: vars.fontSize.xs,
-  ':hover': { borderColor: vars.color.borderHover, color: vars.color.textPrimary },
+  fontWeight: 500,
+  transition: `all 150ms ease`,
+  ':hover': {
+    borderColor: vars.color.borderHover,
+    color: vars.color.textPrimary,
+    background: `color-mix(in srgb, ${vars.color.textPrimary} 5%, transparent)`,
+  },
 });
 
 export const editAccept = style({
   borderColor: vars.color.successMuted,
   color: vars.color.success,
+  background: `color-mix(in srgb, ${vars.color.success} 10%, transparent)`,
+  ':hover': {
+    background: `color-mix(in srgb, ${vars.color.success} 20%, transparent)`,
+    borderColor: vars.color.success,
+    color: vars.color.success,
+  },
 });
 
 export const editDiscard = style({
   borderColor: vars.color.dangerMuted,
   color: vars.color.danger,
+  background: `color-mix(in srgb, ${vars.color.danger} 8%, transparent)`,
+  ':hover': {
+    background: `color-mix(in srgb, ${vars.color.danger} 18%, transparent)`,
+    borderColor: vars.color.danger,
+    color: vars.color.danger,
+  },
 });
 
-export const editDecidedAccepted = style({ opacity: 0.5 });
+export const editDecidedAccepted = style({ opacity: 0.5, borderColor: vars.color.successMuted });
 export const editDecidedDiscarded = style({ opacity: 0.4, textDecoration: 'line-through' });
 
 export const toolBlock = style({
@@ -198,7 +216,7 @@ export const thinkingBlock = style({
 
 export const composerArea = style({
   borderTop: `1px solid ${vars.color.divider}`,
-  padding: `${vars.space.md} ${vars.space.xl} ${vars.space.lg}`,
+  padding: `${vars.space.md} ${vars.space.xxl} ${vars.space.lg}`,
   background: vars.color.bgSecondary,
   display: 'flex',
   flexDirection: 'column',
@@ -395,6 +413,16 @@ export const composerAreaDragOver = style({
 // these styles in chat.css.ts).
 globalStyle(`.${assistantText} pre`, {
   position: 'relative',
+  background: vars.color.bgTertiary,
+  border: `1px solid ${vars.color.border}`,
+  borderRadius: vars.radius.md,
+  padding: vars.space.md,
+  marginTop: vars.space.sm,
+  marginBottom: vars.space.sm,
+  overflowX: 'auto',
+  fontFamily: vars.font.mono,
+  fontSize: vars.fontSize.xs,
+  lineHeight: '1.6',
 });
 
 globalStyle(`.${assistantText} .copy-btn`, {
@@ -416,6 +444,108 @@ globalStyle(`.${assistantText} .copy-btn`, {
 globalStyle(`.${assistantText} .copy-btn:hover`, {
   color: vars.color.textPrimary,
   borderColor: vars.color.borderHover,
+});
+
+// ── Markdown element styles for assistantText innerHTML ──────────────
+
+globalStyle(`.${assistantText} p`, {
+  marginBottom: vars.space.sm,
+});
+globalStyle(`.${assistantText} p:last-child`, {
+  marginBottom: 0,
+});
+
+globalStyle(`.${assistantText} h1`, {
+  fontSize: vars.fontSize.xl,
+  fontWeight: 600,
+  marginTop: vars.space.lg,
+  marginBottom: vars.space.sm,
+});
+globalStyle(`.${assistantText} h2`, {
+  fontSize: vars.fontSize.lg,
+  fontWeight: 600,
+  marginTop: vars.space.lg,
+  marginBottom: vars.space.sm,
+});
+globalStyle(`.${assistantText} h3`, {
+  fontSize: vars.fontSize.md,
+  fontWeight: 600,
+  marginTop: vars.space.md,
+  marginBottom: vars.space.xs,
+});
+globalStyle(`.${assistantText} h4, .${assistantText} h5, .${assistantText} h6`, {
+  fontSize: vars.fontSize.sm,
+  fontWeight: 600,
+  marginTop: vars.space.md,
+  marginBottom: vars.space.xs,
+});
+
+globalStyle(`.${assistantText} :not(pre) > code`, {
+  background: vars.color.bgTertiary,
+  padding: '1px 5px',
+  borderRadius: vars.radius.sm,
+  fontFamily: vars.font.mono,
+  fontSize: '0.9em',
+});
+
+globalStyle(`.${assistantText} ul, .${assistantText} ol`, {
+  paddingLeft: vars.space.xl,
+  marginTop: vars.space.xs,
+  marginBottom: vars.space.sm,
+});
+globalStyle(`.${assistantText} ul`, {
+  listStyleType: 'disc',
+});
+globalStyle(`.${assistantText} ol`, {
+  listStyleType: 'decimal',
+});
+globalStyle(`.${assistantText} li`, {
+  marginBottom: vars.space.xs,
+});
+globalStyle(`.${assistantText} li:last-child`, {
+  marginBottom: 0,
+});
+
+globalStyle(`.${assistantText} a`, {
+  color: vars.color.textLink,
+  textDecoration: 'underline',
+  textUnderlineOffset: '2px',
+});
+globalStyle(`.${assistantText} a:hover`, {
+  color: vars.color.accentHover,
+});
+
+globalStyle(`.${assistantText} blockquote`, {
+  borderLeft: `2px solid ${vars.color.accent}`,
+  paddingLeft: vars.space.md,
+  marginTop: vars.space.sm,
+  marginBottom: vars.space.sm,
+  color: vars.color.textSecondary,
+  fontStyle: 'italic',
+});
+
+globalStyle(`.${assistantText} table`, {
+  width: '100%',
+  borderCollapse: 'collapse',
+  marginTop: vars.space.sm,
+  marginBottom: vars.space.sm,
+  fontSize: vars.fontSize.xs,
+});
+globalStyle(`.${assistantText} th, .${assistantText} td`, {
+  border: `1px solid ${vars.color.border}`,
+  padding: `${vars.space.xs} ${vars.space.sm}`,
+  textAlign: 'left',
+});
+globalStyle(`.${assistantText} th`, {
+  background: vars.color.bgTertiary,
+  fontWeight: 600,
+});
+
+globalStyle(`.${assistantText} hr`, {
+  border: 'none',
+  borderTop: `1px solid ${vars.color.divider}`,
+  marginTop: vars.space.md,
+  marginBottom: vars.space.md,
 });
 
 // ── Past Sessions sidebar (lives inside the Composer pane root) ──────
@@ -628,9 +758,8 @@ export const sidebarToggle = style({
 // the left edge of the main column, so the user always has a way back in.
 export const sidebarExpandFloating = style({
   position: 'absolute',
-  top: '50%',
+  bottom: vars.space.xs,
   left: 0,
-  transform: 'translateY(-50%)',
   background: vars.color.bgSecondary,
   border: `1px solid ${vars.color.border}`,
   borderLeft: 0,

--- a/v2/frontend/src/components/panes/ComposerPane.tsx
+++ b/v2/frontend/src/components/panes/ComposerPane.tsx
@@ -2,7 +2,7 @@
 // Author: Subash Karki
 
 import { createSignal, createEffect, onMount, For, Show, batch } from 'solid-js';
-import { Paperclip, X, FileEdit, Wrench, Brain, ChevronRight, ChevronDown, ChevronLeft, History, Plus, Trash2 } from 'lucide-solid';
+import { Paperclip, X, FileEdit, Wrench, Brain, ChevronRight, ChevronDown, ChevronLeft, History, Plus, Trash2, BookOpen, Zap } from 'lucide-solid';
 import { Select } from '@kobalte/core/select';
 import { ContextMenu } from '@kobalte/core/context-menu';
 import * as sidebarStyles from '@/styles/sidebar.css';
@@ -71,7 +71,14 @@ import {
 import { addTabWithData } from '@/core/panes/signals';
 import { showToast, showWarningToast } from '@/shared/Toast/Toast';
 import { loadPref, setPref } from '@/core/signals/preferences';
+import { Tip } from '@/shared/Tip/Tip';
 import * as styles from './ComposerPane.css';
+import * as metricsStyles from './ComposerMetrics.css';
+import * as turnStyles from './ComposerTurnStyles.css';
+import * as toolStatusStyles from './ComposerToolStatus.css';
+import ComposerMemoryPanel from './ComposerMemoryPanel';
+import ComposerSkillBrowser from './ComposerSkillBrowser';
+import * as strategyStyles from './ComposerStrategy.css';
 
 interface ComposerPaneProps {
   paneId?: string;
@@ -97,7 +104,7 @@ interface TurnView {
   prompt: string;
   text: string;
   thinking: string;
-  toolUses: { name: string; input: string }[];
+  toolUses: { name: string; input: string; status: 'running' | 'done' | 'error' }[];
   editIds: string[];
   status: 'running' | 'done' | 'error' | 'cancelled';
   error?: string;
@@ -105,6 +112,13 @@ interface TurnView {
   outputTokens: number;
   costUSD: number;
   startedAt: number;
+  completedAt: number; // timestamp ms, 0 until done
+  // Strategy metadata — populated once per turn when the orchestrator selects a strategy.
+  strategyName: string;
+  strategyConfidence: number;
+  taskComplexity: string;
+  taskRisk: string;
+  blastRadius: number;
 }
 
 const MODELS = [
@@ -112,6 +126,26 @@ const MODELS = [
   { value: 'opus', label: 'Opus' },
   { value: 'haiku', label: 'Haiku' },
 ];
+
+const EFFORTS = [
+  { value: 'auto', label: 'Auto' },
+  { value: 'low', label: 'Low' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'high', label: 'High' },
+  { value: 'max', label: 'Max' },
+];
+
+const MODEL_CONTEXT_LIMITS: Record<string, number> = {
+  sonnet: 200_000,
+  opus: 200_000,
+  haiku: 200_000,
+};
+
+const formatTokenCount = (n: number): string => {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return `${n}`;
+};
 
 export default function ComposerPane(props: ComposerPaneProps) {
   const paneId = () => props.paneId ?? '';
@@ -121,6 +155,7 @@ export default function ComposerPane(props: ComposerPaneProps) {
   const [edits, setEdits] = createSignal<Record<string, ComposerEditCard>>({});
   const [input, setInput] = createSignal('');
   const [model, setModel] = createSignal<string>('opus');
+  const [effort, setEffort] = createSignal<string>('auto');
   const [running, setRunning] = createSignal(false);
   const [activeTurnId, setActiveTurnId] = createSignal<string | null>(null);
   const [mentions, setMentions] = createSignal<ComposerMention[]>([]);
@@ -130,7 +165,10 @@ export default function ComposerPane(props: ComposerPaneProps) {
   // per-user default so power users who always want clean answers don't
   // have to flip it every time.
   const [noContext, setNoContext] = createSignal(false);
+  const [autoAccept, setAutoAccept] = createSignal(false);
   const [dragOver, setDragOver] = createSignal(false);
+  const [showMemory, setShowMemory] = createSignal(false);
+  const [showSkills, setShowSkills] = createSignal(false);
 
   // Past Sessions sidebar — list, collapsed-state, and the currently
   // active claude session_id. activeSessionId tracks the live session this
@@ -176,6 +214,13 @@ export default function ComposerPane(props: ComposerPaneProps) {
       outputTokens: h.turn.output_tokens,
       costUSD: h.turn.cost_usd,
       startedAt: h.turn.started_at * 1000,
+      completedAt: h.turn.completed_at ? h.turn.completed_at * 1000 : h.turn.started_at * 1000,
+      // Strategy metadata is not persisted — only available during live streaming.
+      strategyName: '',
+      strategyConfidence: 0,
+      taskComplexity: '',
+      taskRisk: '',
+      blastRadius: 0,
     }));
     const editsById: Record<string, ComposerEditCard> = {};
     for (const h of history) for (const e of (h.edits ?? [])) editsById[e.id] = e;
@@ -229,6 +274,11 @@ export default function ComposerPane(props: ComposerPaneProps) {
       if (val === 'true') setSidebarCollapsed(true);
     });
 
+    // Auto-accept edits toggle — when on, edit cards are accepted as they arrive.
+    void loadPref('composer_auto_accept_edits').then((val) => {
+      if (val === 'true') setAutoAccept(true);
+    });
+
     // Kick off the sessions list in parallel — doesn't block history load.
     void refreshSessions();
 
@@ -268,7 +318,10 @@ export default function ComposerPane(props: ComposerPaneProps) {
           case 'tool_use':
             return {
               ...t,
-              toolUses: [...t.toolUses, { name: ev.tool_name ?? 'tool', input: ev.tool_input ?? '' }],
+              toolUses: [
+                ...t.toolUses.map(tu => tu.status === 'running' ? { ...tu, status: 'done' as const } : tu),
+                { name: ev.tool_name ?? 'tool', input: ev.tool_input ?? '', status: 'running' as const },
+              ],
             };
           case 'result':
             return {
@@ -284,9 +337,25 @@ export default function ComposerPane(props: ComposerPaneProps) {
               inputTokens: ev.input_tokens ?? t.inputTokens,
               outputTokens: ev.output_tokens ?? t.outputTokens,
               costUSD: ev.cost_usd ?? t.costUSD,
+              completedAt: Date.now(),
+              toolUses: t.toolUses.map(tu => tu.status === 'running' ? { ...tu, status: 'done' as const } : tu),
             };
           case 'error':
-            return { ...t, status: 'error', error: ev.content ?? 'Unknown error' };
+            return {
+              ...t,
+              status: 'error',
+              error: ev.content ?? 'Unknown error',
+              toolUses: t.toolUses.map(tu => tu.status === 'running' ? { ...tu, status: 'error' as const } : tu),
+            };
+          case 'strategy':
+            return {
+              ...t,
+              strategyName: ev.strategy_name ?? t.strategyName,
+              strategyConfidence: ev.strategy_confidence ?? t.strategyConfidence,
+              taskComplexity: ev.task_complexity ?? t.taskComplexity,
+              taskRisk: ev.task_risk ?? t.taskRisk,
+              blastRadius: ev.blast_radius ?? t.blastRadius,
+            };
           default:
             return t;
         }
@@ -312,6 +381,9 @@ export default function ComposerPane(props: ComposerPaneProps) {
       );
     });
     scrollToBottom();
+    if (autoAccept()) {
+      void composerDecideEdit(card.id, true);
+    }
   });
 
   onWailsEvent<{ id: string; status: 'accepted' | 'discarded' }>('composer:edit-decided', (msg) => {
@@ -341,13 +413,19 @@ export default function ComposerPane(props: ComposerPaneProps) {
       outputTokens: 0,
       costUSD: 0,
       startedAt: Date.now(),
+      completedAt: 0,
+      strategyName: '',
+      strategyConfidence: 0,
+      taskComplexity: '',
+      taskRisk: '',
+      blastRadius: 0,
     };
     setTurns((prev) => [...prev, turn]);
     setRunning(true);
     setInput('');
     scrollToBottom();
 
-    const newId = await composerSend(paneId(), prompt, cwd(), model(), mentions(), noContext());
+    const newId = await composerSend(paneId(), prompt, cwd(), model(), mentions(), noContext(), effort());
     if (!newId) {
       setTurns((prev) =>
         prev.map((t) => (t.id === turnId ? { ...t, status: 'error', error: 'Failed to send' } : t)),
@@ -547,6 +625,18 @@ export default function ComposerPane(props: ComposerPaneProps) {
     void setPref('composer_no_context_default', next ? 'true' : 'false');
   };
 
+  const toggleAutoAccept = () => {
+    const next = !autoAccept();
+    setAutoAccept(next);
+    void setPref('composer_auto_accept_edits', next ? 'true' : 'false');
+  };
+
+  const handleSkillInvoke = (skillName: string) => {
+    setInput(skillName + ' ');
+    setShowSkills(false);
+    textareaRef?.focus();
+  };
+
   const handleAcceptEdit = async (id: string) => {
     await composerDecideEdit(id, true);
   };
@@ -594,6 +684,26 @@ export default function ComposerPane(props: ComposerPaneProps) {
   const totalCostThisTurn = () => {
     const last = turns()[turns().length - 1];
     return last && last.costUSD > 0 ? `$${last.costUSD.toFixed(4)}` : '';
+  };
+
+  // ── Session-level computed metrics ─────────────────────────────────────
+  const sessionTotalCost = () => turns().reduce((sum, t) => sum + t.costUSD, 0);
+  const sessionTotalTokens = () => turns().reduce((sum, t) => sum + t.inputTokens + t.outputTokens, 0);
+  const sessionTurnCount = () => turns().length;
+
+  // ── Context window gauge ───────────────────────────────────────────────
+  const contextUsed = () => {
+    const t = turns();
+    if (t.length === 0) return 0;
+    return t[t.length - 1].inputTokens;
+  };
+  const contextMax = () => MODEL_CONTEXT_LIMITS[model()] ?? 200_000;
+  const contextPercent = () => Math.min(100, (contextUsed() / contextMax()) * 100);
+  const contextColor = () => {
+    const pct = contextPercent();
+    if (pct >= 80) return 'danger';
+    if (pct >= 60) return 'warning';
+    return 'accent';
   };
 
   // Format a "Xm/Xh/Xd" relative timestamp for sidebar rows.
@@ -657,7 +767,7 @@ export default function ComposerPane(props: ComposerPaneProps) {
                       <ContextMenu.Content class={sidebarStyles.contextMenuContent}>
                         <ContextMenu.Item
                           class={sidebarStyles.contextMenuItem}
-                          onSelect={() => addTabWithData('composer', { cwd: s.cwd, sessionId: s.session_id })}
+                          onSelect={() => addTabWithData('composer', `Composer · ${basename(s.cwd) || 'session'}`, { cwd: s.cwd, sessionId: s.session_id })}
                         >
                           <Plus size={13} />
                           Open in new tab
@@ -725,12 +835,37 @@ export default function ComposerPane(props: ComposerPaneProps) {
         >
           {noContext() ? '🌐 No project context' : '📁 Project context on'}
         </button>
+        <button
+          class={`${styles.contextPill} ${autoAccept() ? styles.contextPillActive : ''}`}
+          type="button"
+          onClick={toggleAutoAccept}
+          disabled={running()}
+          title={
+            autoAccept()
+              ? 'Edits are auto-accepted as they arrive (files already written to disk).'
+              : 'Edit cards require manual accept/discard.'
+          }
+        >
+          {autoAccept() ? '⚡ Auto-accept on' : '✋ Manual review'}
+        </button>
         <span class={styles.statusGrow} />
-        <Show when={totalTokensThisTurn()}>
-          <span>{totalTokensThisTurn()}</span>
-        </Show>
-        <Show when={totalCostThisTurn()}>
-          <span>· {totalCostThisTurn()}</span>
+        <Show when={turns().length > 0}>
+          <span class={metricsStyles.metricsSeparator}>|</span>
+          <span class={metricsStyles.metricsGroup}>
+            <span>Turn {sessionTurnCount()}</span>
+            <span class={metricsStyles.metricsDot}>&middot;</span>
+            <span>{totalTokensThisTurn()}</span>
+            <Show when={totalCostThisTurn()}>
+              <span class={metricsStyles.metricsDot}>&middot;</span>
+              <span>{totalCostThisTurn()}</span>
+            </Show>
+          </span>
+          <span class={metricsStyles.metricsSeparator}>|</span>
+          <span class={metricsStyles.sessionTotal}>
+            Session: ${sessionTotalCost().toFixed(4)}
+            <span class={metricsStyles.metricsDot}>&middot;</span>
+            {formatTokenCount(sessionTotalTokens())} tok
+          </span>
         </Show>
         <Show when={running()}>
           <button class={styles.cancelBtn} type="button" onClick={handleCancel}>
@@ -752,6 +887,22 @@ export default function ComposerPane(props: ComposerPaneProps) {
         </Show>
       </div>
 
+      {/* Context window gauge */}
+      <Show when={contextUsed() > 0}>
+        <div class={metricsStyles.contextGauge} title={`Context: ${formatTokenCount(contextUsed())} / ${formatTokenCount(contextMax())} tokens (${contextPercent().toFixed(0)}%)`}>
+          <div
+            class={metricsStyles.contextGaugeFill}
+            style={{
+              width: `${contextPercent()}%`,
+              background: `var(--gauge-color-${contextColor()})`,
+            }}
+          />
+          <span class={metricsStyles.contextGaugeLabel}>
+            {formatTokenCount(contextUsed())} / {formatTokenCount(contextMax())} ({contextPercent().toFixed(0)}%)
+          </span>
+        </div>
+      </Show>
+
       {/* Conversation feed */}
       <div class={styles.feed} ref={feedRef}>
         <Show when={turns().length === 0}>
@@ -763,11 +914,20 @@ export default function ComposerPane(props: ComposerPaneProps) {
 
         <For each={turns()}>
           {(turn) => (
-            <div style={{ display: 'flex', 'flex-direction': 'column', gap: '8px' }}>
+            <div class={turnStyles.turnGroup}>
               <Show when={turn.prompt}>
                 <div class={styles.userTurn}>{turn.prompt}</div>
               </Show>
 
+              <Show when={turn.strategyName}>
+                <StrategyChip
+                  name={turn.strategyName}
+                  confidence={turn.strategyConfidence}
+                  complexity={turn.taskComplexity}
+                  risk={turn.taskRisk}
+                  blastRadius={turn.blastRadius}
+                />
+              </Show>
               {/* Pre-stream "thinking" pulse — shows the moment user sends,
                   hides as soon as ANY content arrives (thinking/tool/text/edit)
                   or the turn settles (done/error). */}
@@ -793,7 +953,7 @@ export default function ComposerPane(props: ComposerPaneProps) {
               </Show>
 
               <For each={turn.toolUses}>
-                {(t) => <ToolUseChip name={t.name} input={t.input} />}
+                {(t) => <ToolUseChip name={t.name} input={t.input} status={t.status} />}
               </For>
 
               <For each={turn.editIds}>
@@ -815,7 +975,10 @@ export default function ComposerPane(props: ComposerPaneProps) {
               </For>
 
               <Show when={turn.text}>
-                <ComposerMarkdown text={turn.text} />
+                <div>
+                  <span class={turnStyles.assistantBadge}>ASSISTANT</span>
+                  <ComposerMarkdown text={turn.text} />
+                </div>
               </Show>
 
               <Show when={turn.status === 'error' && turn.error}>
@@ -824,10 +987,14 @@ export default function ComposerPane(props: ComposerPaneProps) {
                 </div>
               </Show>
 
-              <Show when={turn.status === 'done' && turn.editIds.length > 0}>
+              <Show when={turn.status === 'done' || turn.status === 'error'}>
+                <TurnMetrics turn={turn} turnIndex={turns().indexOf(turn)} edits={edits()} />
+              </Show>
+
+              <Show when={turn.status === 'done' && turn.editIds.length > 0 && !autoAccept() && pendingEditCards().length > 0}>
                 <div style={{ display: 'flex', gap: '8px' }}>
                   <button class={`${styles.editBtn} ${styles.editAccept}`} type="button" onClick={acceptAll}>
-                    Accept all
+                    Accept all ({pendingEditCards().length})
                   </button>
                   <button
                     class={`${styles.editBtn} ${styles.editDiscard}`}
@@ -880,14 +1047,35 @@ export default function ComposerPane(props: ComposerPaneProps) {
         />
 
         <div class={styles.composerToolbar}>
-          <button
-            class={styles.editBtn}
-            type="button"
-            onClick={handleAttachClick}
-            title="Attach a file (or paste an image into the textarea)"
-          >
-            <Paperclip size={12} />
-          </button>
+          <Tip label="Attach file or paste image" placement="top">
+            <button
+              class={styles.editBtn}
+              type="button"
+              onClick={handleAttachClick}
+            >
+              <Paperclip size={12} />
+            </button>
+          </Tip>
+
+          <Tip label="Memory context" placement="top">
+            <button
+              class={styles.editBtn}
+              type="button"
+              onClick={() => setShowMemory(!showMemory())}
+            >
+              <BookOpen size={12} />
+            </button>
+          </Tip>
+
+          <Tip label="Skills browser" placement="top">
+            <button
+              class={styles.editBtn}
+              type="button"
+              onClick={() => setShowSkills(!showSkills())}
+            >
+              <Zap size={12} />
+            </button>
+          </Tip>
 
           <Select<string>
             value={model()}
@@ -901,9 +1089,39 @@ export default function ComposerPane(props: ComposerPaneProps) {
               </Select.Item>
             )}
           >
-            <Select.Trigger class={styles.modelSelectTrigger}>
+            <Select.Trigger class={styles.modelSelectTrigger} title="Select Claude model">
               <Select.Value<string> class={styles.modelSelectValue}>
                 {(state) => MODELS.find((m) => m.value === state.selectedOption())?.label ?? state.selectedOption()}
+              </Select.Value>
+              <Select.Icon class={styles.modelSelectIcon}>
+                <ChevronDown size={12} />
+              </Select.Icon>
+            </Select.Trigger>
+            <Select.Portal>
+              <Select.Content class={styles.modelSelectContent}>
+                <Select.Listbox class={styles.modelSelectListbox} />
+              </Select.Content>
+            </Select.Portal>
+          </Select>
+
+          <Select<string>
+            value={effort()}
+            onChange={(val) => { if (val !== null) setEffort(val); }}
+            options={EFFORTS.map((e) => e.value)}
+            itemComponent={(itemProps) => (
+              <Select.Item item={itemProps.item} class={styles.modelSelectItem}>
+                <Select.ItemLabel class={styles.modelSelectItemLabel}>
+                  {EFFORTS.find((e) => e.value === itemProps.item.rawValue)?.label ?? itemProps.item.rawValue}
+                </Select.ItemLabel>
+              </Select.Item>
+            )}
+          >
+            <Select.Trigger class={styles.modelSelectTrigger} title="Reasoning effort level">
+              <Select.Value<string> class={styles.modelSelectValue}>
+                {(state) => {
+                  const label = EFFORTS.find((e) => e.value === state.selectedOption())?.label ?? state.selectedOption();
+                  return `Effort: ${label}`;
+                }}
               </Select.Value>
               <Select.Icon class={styles.modelSelectIcon}>
                 <ChevronDown size={12} />
@@ -921,32 +1139,81 @@ export default function ComposerPane(props: ComposerPaneProps) {
         </div>
       </div>
       </div>{/* /main */}
+
+      {/* Memory context right rail — toggled from composer toolbar. */}
+      <Show when={showMemory()}>
+        <ComposerMemoryPanel cwd={cwd()} onClose={() => setShowMemory(false)} />
+      </Show>
+
+      {/* Skill browser right rail — toggled from composer toolbar. */}
+      <Show when={showSkills()}>
+        <ComposerSkillBrowser
+          cwd={cwd()}
+          onInvoke={handleSkillInvoke}
+          onClose={() => setShowSkills(false)}
+        />
+      </Show>
     </div>
   );
 }
 
 // ── Sub-components ─────────────────────────────────────────────────────
 
+function StrategyChip(props: { name: string; confidence: number; complexity: string; risk: string; blastRadius: number }) {
+  const [open, setOpen] = createSignal(false);
+  return (
+    <div class={strategyStyles.strategyBlock} onClick={() => setOpen(!open())}>
+      <div class={strategyStyles.strategyHeader}>
+        <Brain size={11} />
+        <Show when={open()} fallback={<ChevronRight size={11} />}>
+          <ChevronDown size={11} />
+        </Show>
+        <span>Strategy: </span>
+        <span class={strategyStyles.strategyName}>{props.name}</span>
+        <span class={strategyStyles.strategyConfidence}>({(props.confidence * 100).toFixed(0)}%)</span>
+      </div>
+      <Show when={open()}>
+        <div class={strategyStyles.strategyDetails}>
+          <span class={strategyStyles.strategyTag}>Complexity: {props.complexity}</span>
+          <span class={strategyStyles.strategyTag}>Risk: {props.risk}</span>
+          <span class={strategyStyles.strategyTag}>Blast radius: {props.blastRadius} files</span>
+        </div>
+      </Show>
+    </div>
+  );
+}
+
 function ThinkingChip(props: { content: string }) {
   const [open, setOpen] = createSignal(false);
   return (
-    <div class={styles.thinkingBlock} onClick={() => setOpen(!open())} style={{ cursor: 'pointer' }}>
+    <div
+      class={open() ? toolStatusStyles.thinkingExpanded : toolStatusStyles.thinkingCollapsed}
+      onClick={() => setOpen(!open())}
+    >
       <Brain size={11} style={{ 'vertical-align': 'middle', 'margin-right': '4px' }} />
       <Show when={open()} fallback={<ChevronRight size={11} style={{ 'vertical-align': 'middle' }} />}>
         <ChevronDown size={11} style={{ 'vertical-align': 'middle' }} />
       </Show>
       <span style={{ 'margin-left': '4px' }}>Thinking…</span>
       <Show when={open()}>
-        <div style={{ 'margin-top': '4px' }}>{props.content}</div>
+        <div class={toolStatusStyles.thinkingContent}>{props.content}</div>
       </Show>
     </div>
   );
 }
 
-function ToolUseChip(props: { name: string; input: string }) {
+function ToolUseChip(props: { name: string; input: string; status: 'running' | 'done' | 'error' }) {
   const [open, setOpen] = createSignal(false);
+  const dotClass = () => {
+    switch (props.status) {
+      case 'running': return toolStatusStyles.statusDotRunning;
+      case 'error': return toolStatusStyles.statusDotError;
+      default: return toolStatusStyles.statusDotSuccess;
+    }
+  };
   return (
     <div class={styles.toolBlock} onClick={() => setOpen(!open())} style={{ cursor: 'pointer' }}>
+      <span class={dotClass()} />
       <Wrench size={11} style={{ 'vertical-align': 'middle', 'margin-right': '4px' }} />
       <Show when={open()} fallback={<ChevronRight size={11} style={{ 'vertical-align': 'middle' }} />}>
         <ChevronDown size={11} style={{ 'vertical-align': 'middle' }} />
@@ -956,6 +1223,47 @@ function ToolUseChip(props: { name: string; input: string }) {
         <pre style={{ 'margin-top': '4px', 'white-space': 'pre-wrap', 'word-break': 'break-all' }}>
           {props.input}
         </pre>
+      </Show>
+    </div>
+  );
+}
+
+function TurnMetrics(props: { turn: TurnView; turnIndex: number; edits: Record<string, ComposerEditCard> }) {
+  const duration = () => {
+    if (!props.turn.completedAt || !props.turn.startedAt) return '';
+    const sec = Math.round((props.turn.completedAt - props.turn.startedAt) / 1000);
+    if (sec < 60) return `${sec}s`;
+    const m = Math.floor(sec / 60);
+    const s = sec % 60;
+    return `${m}m ${s}s`;
+  };
+
+  const filesEdited = () => props.turn.editIds.length;
+  const linesChanged = () => {
+    let added = 0, removed = 0;
+    for (const id of props.turn.editIds) {
+      const card = props.edits[id];
+      if (card) { added += card.lines_added; removed += card.lines_removed; }
+    }
+    return { added, removed };
+  };
+
+  return (
+    <div class={metricsStyles.turnMetrics}>
+      <span>Turn {props.turnIndex + 1}</span>
+      <Show when={duration()}>
+        <span class={metricsStyles.metricsDot}>&middot;</span>
+        <span>{duration()}</span>
+      </Show>
+      <span class={metricsStyles.metricsDot}>&middot;</span>
+      <span>{formatTokenCount(props.turn.inputTokens)} in / {formatTokenCount(props.turn.outputTokens)} out</span>
+      <span class={metricsStyles.metricsDot}>&middot;</span>
+      <span>${props.turn.costUSD.toFixed(4)}</span>
+      <Show when={filesEdited() > 0}>
+        <span class={metricsStyles.metricsDot}>&middot;</span>
+        <span>{filesEdited()} file{filesEdited() > 1 ? 's' : ''}</span>
+        <span class={metricsStyles.turnLinesAdded}>+{linesChanged().added}</span>
+        <span class={metricsStyles.turnLinesRemoved}>-{linesChanged().removed}</span>
       </Show>
     </div>
   );

--- a/v2/frontend/src/components/panes/ComposerSkillBrowser.css.ts
+++ b/v2/frontend/src/components/panes/ComposerSkillBrowser.css.ts
@@ -1,0 +1,126 @@
+// Author: Subash Karki
+import { style } from '@vanilla-extract/css';
+import { vars } from '@/styles/theme.css';
+
+export const panel = style({
+  display: 'flex',
+  flexDirection: 'column',
+  width: 280,
+  flex: '0 0 280px',
+  borderLeft: `1px solid ${vars.color.divider}`,
+  background: vars.color.bgSecondary,
+  overflow: 'hidden',
+});
+
+export const panelHeader = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: vars.space.xs,
+  padding: `${vars.space.sm} ${vars.space.md}`,
+  borderBottom: `1px solid ${vars.color.divider}`,
+  color: vars.color.textPrimary,
+  fontSize: vars.fontSize.xs,
+});
+
+export const panelTitle = style({
+  fontWeight: 600,
+  flex: 1,
+});
+
+export const panelCount = style({
+  fontFamily: vars.font.mono,
+  fontSize: '10px',
+  color: vars.color.textDisabled,
+  padding: '1px 5px',
+  borderRadius: vars.radius.sm,
+  background: vars.color.bgTertiary,
+});
+
+export const panelClose = style({
+  background: 'transparent',
+  border: 'none',
+  color: vars.color.textDisabled,
+  cursor: 'pointer',
+  padding: '2px',
+  fontSize: vars.fontSize.xs,
+  ':hover': { color: vars.color.textPrimary },
+});
+
+export const searchRow = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: vars.space.xs,
+  padding: `${vars.space.xs} ${vars.space.sm}`,
+  borderBottom: `1px solid ${vars.color.divider}`,
+  color: vars.color.textDisabled,
+});
+
+export const searchInput = style({
+  flex: 1,
+  background: 'transparent',
+  border: 'none',
+  color: vars.color.textPrimary,
+  fontSize: vars.fontSize.xs,
+  fontFamily: vars.font.body,
+  outline: 'none',
+  '::placeholder': { color: vars.color.textDisabled },
+});
+
+export const panelBody = style({
+  flex: 1,
+  overflowY: 'auto',
+  padding: vars.space.sm,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.space.xs,
+});
+
+export const panelEmpty = style({
+  padding: vars.space.lg,
+  textAlign: 'center',
+  fontStyle: 'italic',
+  color: vars.color.textDisabled,
+  fontSize: vars.fontSize.xs,
+});
+
+export const skillCard = style({
+  padding: vars.space.sm,
+  borderRadius: vars.radius.sm,
+  border: `1px solid ${vars.color.border}`,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.space.xs,
+});
+
+export const skillName = style({
+  fontFamily: vars.font.mono,
+  fontWeight: 600,
+  fontSize: vars.fontSize.xs,
+  color: vars.color.accent,
+});
+
+export const skillDesc = style({
+  fontSize: '10px',
+  color: vars.color.textSecondary,
+  lineHeight: '1.4',
+  display: '-webkit-box',
+  WebkitLineClamp: 2,
+  WebkitBoxOrient: 'vertical',
+  overflow: 'hidden',
+});
+
+export const skillInvoke = style({
+  alignSelf: 'flex-start',
+  background: 'transparent',
+  border: `1px solid ${vars.color.border}`,
+  color: vars.color.textSecondary,
+  padding: '2px 8px',
+  borderRadius: vars.radius.sm,
+  cursor: 'pointer',
+  fontSize: '10px',
+  fontFamily: vars.font.mono,
+  ':hover': {
+    borderColor: vars.color.accent,
+    color: vars.color.accent,
+  },
+});

--- a/v2/frontend/src/components/panes/ComposerSkillBrowser.tsx
+++ b/v2/frontend/src/components/panes/ComposerSkillBrowser.tsx
@@ -1,0 +1,78 @@
+// Author: Subash Karki
+import { createSignal, onMount, For, Show } from 'solid-js';
+import { Zap, Search } from 'lucide-solid';
+import { composerListSkills, type ComposerSkill } from '@/core/bindings/composer';
+import * as styles from './ComposerSkillBrowser.css';
+
+interface SkillBrowserProps {
+  cwd: string;
+  onInvoke: (skillName: string) => void;
+  onClose: () => void;
+}
+
+export default function ComposerSkillBrowser(props: SkillBrowserProps) {
+  const [skills, setSkills] = createSignal<ComposerSkill[]>([]);
+  const [filter, setFilter] = createSignal('');
+
+  onMount(async () => {
+    const list = await composerListSkills(props.cwd);
+    setSkills(list);
+  });
+
+  const filtered = () => {
+    const q = filter().toLowerCase();
+    if (!q) return skills();
+    return skills().filter(s =>
+      s.name.toLowerCase().includes(q) || s.description.toLowerCase().includes(q)
+    );
+  };
+
+  return (
+    <div class={styles.panel}>
+      <div class={styles.panelHeader}>
+        <Zap size={12} />
+        <span class={styles.panelTitle}>Skills</span>
+        <span class={styles.panelCount}>{skills().length}</span>
+        <button class={styles.panelClose} type="button" onClick={props.onClose}>
+          ✕
+        </button>
+      </div>
+      <div class={styles.searchRow}>
+        <Search size={11} />
+        <input
+          class={styles.searchInput}
+          type="text"
+          placeholder="Filter skills..."
+          value={filter()}
+          onInput={(e) => setFilter(e.currentTarget.value)}
+        />
+      </div>
+      <div class={styles.panelBody}>
+        <Show when={filtered().length === 0}>
+          <div class={styles.panelEmpty}>
+            {skills().length === 0
+              ? 'No skills found in .claude/skills/'
+              : 'No matching skills'}
+          </div>
+        </Show>
+        <For each={filtered()}>
+          {(skill) => (
+            <div class={styles.skillCard}>
+              <div class={styles.skillName}>/{skill.name}</div>
+              <Show when={skill.description}>
+                <div class={styles.skillDesc}>{skill.description}</div>
+              </Show>
+              <button
+                class={styles.skillInvoke}
+                type="button"
+                onClick={() => props.onInvoke(`/${skill.name}`)}
+              >
+                Invoke
+              </button>
+            </div>
+          )}
+        </For>
+      </div>
+    </div>
+  );
+}

--- a/v2/frontend/src/components/panes/ComposerStrategy.css.ts
+++ b/v2/frontend/src/components/panes/ComposerStrategy.css.ts
@@ -1,0 +1,50 @@
+// Author: Subash Karki
+
+import { style } from '@vanilla-extract/css';
+import { vars } from '@/styles/theme.css';
+
+export const strategyBlock = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.space.xs,
+  padding: `${vars.space.sm} ${vars.space.md}`,
+  background: `color-mix(in srgb, ${vars.color.accent} 5%, ${vars.color.bgSecondary})`,
+  borderRadius: vars.radius.md,
+  border: `1px solid ${vars.color.border}`,
+  fontSize: vars.fontSize.xs,
+  cursor: 'pointer',
+});
+
+export const strategyHeader = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: vars.space.sm,
+  color: vars.color.textSecondary,
+});
+
+export const strategyName = style({
+  fontWeight: 600,
+  color: vars.color.accent,
+  fontFamily: vars.font.mono,
+});
+
+export const strategyConfidence = style({
+  fontFamily: vars.font.mono,
+  color: vars.color.textDisabled,
+});
+
+export const strategyDetails = style({
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: vars.space.md,
+  color: vars.color.textDisabled,
+  fontFamily: vars.font.mono,
+  fontSize: '10px',
+});
+
+export const strategyTag = style({
+  padding: '1px 6px',
+  borderRadius: vars.radius.sm,
+  background: vars.color.bgTertiary,
+  border: `1px solid ${vars.color.border}`,
+});

--- a/v2/frontend/src/components/panes/ComposerToolStatus.css.ts
+++ b/v2/frontend/src/components/panes/ComposerToolStatus.css.ts
@@ -1,0 +1,70 @@
+// Author: Subash Karki
+import { style, keyframes } from '@vanilla-extract/css';
+import { vars } from '@/styles/theme.css';
+
+const blink = keyframes({
+  '0%, 100%': { opacity: 1 },
+  '50%': { opacity: 0.3 },
+});
+
+export const statusDotRunning = style({
+  display: 'inline-block',
+  width: 6,
+  height: 6,
+  borderRadius: '50%',
+  background: vars.color.accent,
+  animation: `${blink} 1s ease-in-out infinite`,
+  marginRight: vars.space.xs,
+  verticalAlign: 'middle',
+});
+
+export const statusDotSuccess = style({
+  display: 'inline-block',
+  width: 6,
+  height: 6,
+  borderRadius: '50%',
+  background: vars.color.success,
+  marginRight: vars.space.xs,
+  verticalAlign: 'middle',
+});
+
+export const statusDotError = style({
+  display: 'inline-block',
+  width: 6,
+  height: 6,
+  borderRadius: '50%',
+  background: vars.color.danger,
+  marginRight: vars.space.xs,
+  verticalAlign: 'middle',
+});
+
+export const thinkingCollapsed = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: vars.space.xs,
+  fontStyle: 'italic',
+  fontSize: vars.fontSize.xs,
+  color: vars.color.textDisabled,
+  padding: `${vars.space.xs} ${vars.space.sm}`,
+  borderLeft: `2px solid ${vars.color.accent}`,
+  cursor: 'pointer',
+  ':hover': {
+    color: vars.color.textSecondary,
+  },
+});
+
+export const thinkingExpanded = style({
+  fontStyle: 'italic',
+  fontSize: vars.fontSize.xs,
+  color: vars.color.textDisabled,
+  padding: `${vars.space.xs} ${vars.space.sm}`,
+  borderLeft: `2px solid ${vars.color.accent}`,
+  whiteSpace: 'pre-wrap',
+  cursor: 'pointer',
+});
+
+export const thinkingContent = style({
+  marginTop: vars.space.xs,
+  maxHeight: '200px',
+  overflowY: 'auto',
+});

--- a/v2/frontend/src/components/panes/ComposerTurnStyles.css.ts
+++ b/v2/frontend/src/components/panes/ComposerTurnStyles.css.ts
@@ -1,0 +1,27 @@
+// Author: Subash Karki
+import { style } from '@vanilla-extract/css';
+import { vars } from '@/styles/theme.css';
+
+export const turnGroup = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '8px',
+  selectors: {
+    '& + &': {
+      borderTop: `1px solid ${vars.color.divider}`,
+      paddingTop: vars.space.lg,
+    },
+  },
+});
+
+export const assistantBadge = style({
+  display: 'inline-block',
+  marginBottom: vars.space.xs,
+  padding: '1px 6px',
+  borderRadius: vars.radius.sm,
+  background: vars.color.bgTertiary,
+  color: vars.color.textSecondary,
+  fontSize: '10px',
+  fontWeight: 600,
+  letterSpacing: '0.05em',
+});

--- a/v2/frontend/src/core/bindings/composer.ts
+++ b/v2/frontend/src/core/bindings/composer.ts
@@ -26,13 +26,19 @@ export interface ComposerEditCard {
 export interface ComposerEvent {
   pane_id: string;
   turn_id?: string;
-  type: 'delta' | 'thinking' | 'tool_use' | 'result' | 'done' | 'error';
+  type: 'delta' | 'thinking' | 'tool_use' | 'result' | 'done' | 'error' | 'strategy';
   content?: string;
   tool_name?: string;
   tool_input?: string;
   input_tokens?: number;
   output_tokens?: number;
   cost_usd?: number;
+  // Strategy-specific fields, populated on type=="strategy".
+  strategy_name?: string;
+  strategy_confidence?: number;
+  task_complexity?: string;
+  task_risk?: string;
+  blast_radius?: number;
 }
 
 /**
@@ -42,6 +48,8 @@ export interface ComposerEvent {
  *   --setting-sources "" so it has zero awareness of the user's project
  *   (no CLAUDE.md, .claude/, hooks, settings, skills). Defaults to false —
  *   existing callers see no behaviour change.
+ * @param effort Reasoning effort level ('low' | 'medium' | 'high' | 'max').
+ *   Empty string means "don't pass the flag" (auto/default).
  */
 export async function composerSend(
   paneId: string,
@@ -50,9 +58,10 @@ export async function composerSend(
   model: string,
   mentions: ComposerMention[],
   noContext = false,
+  effort = '',
 ): Promise<string> {
   try {
-    const id = await App()?.ComposerSend(paneId, prompt, cwd, model, mentions, noContext);
+    const id = await App()?.ComposerSend(paneId, prompt, cwd, model, mentions, noContext, effort);
     return typeof id === 'string' ? id : '';
   } catch {
     return '';
@@ -188,5 +197,50 @@ export async function composerDeleteSession(sessionId: string): Promise<boolean>
     return true;
   } catch {
     return false;
+  }
+}
+
+// ── Memory context ────────────────────────────────────────────────────
+
+export interface MemoryContextItem {
+  level: 'global' | 'project' | 'rule';
+  path: string;
+  content: string;
+  size: number;
+}
+
+/**
+ * Read CLAUDE.md files and .claude/rules/ from the project (and global
+ * ~/.claude/CLAUDE.md). Returns an empty array if the binding is missing
+ * (e.g. running outside Wails).
+ */
+export async function composerGetMemoryContext(cwd: string): Promise<MemoryContextItem[]> {
+  try {
+    const raw = (await App()?.ComposerGetMemoryContext(cwd)) ?? [];
+    return normalize<MemoryContextItem[]>(raw);
+  } catch {
+    return [];
+  }
+}
+
+// ── Skill browser ─────────────────────────────────────────────────────
+
+export interface ComposerSkill {
+  id: string;
+  name: string;
+  description: string;
+  path: string;
+}
+
+/**
+ * List available skills from <cwd>/.claude/skills/. Each skill directory
+ * must contain a SKILL.md with optional YAML frontmatter (name, description).
+ */
+export async function composerListSkills(cwd: string): Promise<ComposerSkill[]> {
+  try {
+    const raw = (await App()?.ComposerListSkills(cwd)) ?? [];
+    return normalize<ComposerSkill[]>(raw);
+  } catch {
+    return [];
   }
 }

--- a/v2/internal/app/bindings_composer.go
+++ b/v2/internal/app/bindings_composer.go
@@ -19,7 +19,10 @@ import (
 // noContext, when true, runs the turn with --setting-sources "" inside a
 // fresh temp directory so the agent has zero workspace awareness. Used by
 // the "No project context" toggle in the Composer status strip.
-func (a *App) ComposerSend(paneID, prompt, cwd, model string, mentions []composer.Mention, noContext bool) string {
+//
+// effort controls the reasoning effort level ("low", "medium", "high", "max").
+// Empty string means "don't pass the flag" (auto/default).
+func (a *App) ComposerSend(paneID, prompt, cwd, model string, mentions []composer.Mention, noContext bool, effort string) string {
 	if a.Composer == nil {
 		slog.Warn("ComposerSend: composer service not initialised")
 		return ""
@@ -31,6 +34,7 @@ func (a *App) ComposerSend(paneID, prompt, cwd, model string, mentions []compose
 		Model:     model,
 		Mentions:  mentions,
 		NoContext: noContext,
+		Effort:   effort,
 	})
 	if err != nil {
 		slog.Error("ComposerSend failed", "pane", paneID, "err", err)
@@ -166,6 +170,68 @@ func (a *App) ComposerDeleteSession(sessionID string) error {
 		return err
 	}
 	return nil
+}
+
+// ComposerGetMemoryContext reads CLAUDE.md files and .claude/rules/ from
+// the project (and the global ~/.claude/CLAUDE.md), returning them as a
+// list of {level, path, content, size} maps. Drives the Memory Viewer
+// panel in the Composer toolbar.
+func (a *App) ComposerGetMemoryContext(cwd string) []map[string]interface{} {
+	var result []map[string]interface{}
+
+	// Global CLAUDE.md
+	globalPath := filepath.Join(os.Getenv("HOME"), ".claude", "CLAUDE.md")
+	if content, err := os.ReadFile(globalPath); err == nil {
+		result = append(result, map[string]interface{}{
+			"level":   "global",
+			"path":    globalPath,
+			"content": string(content),
+			"size":    len(content),
+		})
+	}
+
+	// Project CLAUDE.md
+	projectPath := filepath.Join(cwd, "CLAUDE.md")
+	if content, err := os.ReadFile(projectPath); err == nil {
+		result = append(result, map[string]interface{}{
+			"level":   "project",
+			"path":    projectPath,
+			"content": string(content),
+			"size":    len(content),
+		})
+	}
+
+	// .claude/CLAUDE.md
+	dotClaudePath := filepath.Join(cwd, ".claude", "CLAUDE.md")
+	if content, err := os.ReadFile(dotClaudePath); err == nil {
+		result = append(result, map[string]interface{}{
+			"level":   "project",
+			"path":    dotClaudePath,
+			"content": string(content),
+			"size":    len(content),
+		})
+	}
+
+	// Rules directory
+	rulesDir := filepath.Join(cwd, ".claude", "rules")
+	if entries, err := os.ReadDir(rulesDir); err == nil {
+		for _, entry := range entries {
+			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") {
+				continue
+			}
+			rulePath := filepath.Join(rulesDir, entry.Name())
+			if content, err := os.ReadFile(rulePath); err == nil {
+				result = append(result, map[string]interface{}{
+					"level":   "rule",
+					"path":    rulePath,
+					"content": string(content),
+					"size":    len(content),
+				})
+			}
+		}
+	}
+
+	return result
 }
 
 // ComposerListPending returns all pending edit cards for a pane (used on

--- a/v2/internal/app/bindings_composer_skills.go
+++ b/v2/internal/app/bindings_composer_skills.go
@@ -1,0 +1,63 @@
+// Wails binding: list available Claude skills from .claude/skills/.
+// Author: Subash Karki
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ComposerListSkills scans <cwd>/.claude/skills/ for skill directories
+// containing a SKILL.md file, parses YAML frontmatter for name/description,
+// and returns the list. Returns an empty slice (never nil) on any error so
+// the frontend always gets a JSON array.
+func (a *App) ComposerListSkills(cwd string) []map[string]interface{} {
+	skills := []map[string]interface{}{}
+
+	skillsDir := filepath.Join(cwd, ".claude", "skills")
+	entries, err := os.ReadDir(skillsDir)
+	if err != nil {
+		return skills
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		skillPath := filepath.Join(skillsDir, entry.Name(), "SKILL.md")
+		content, err := os.ReadFile(skillPath)
+		if err != nil {
+			continue
+		}
+
+		// Parse YAML frontmatter (--- delimited).
+		text := string(content)
+		name := entry.Name()
+		description := ""
+
+		if strings.HasPrefix(text, "---") {
+			endIdx := strings.Index(text[3:], "---")
+			if endIdx > 0 {
+				frontmatter := text[3 : 3+endIdx]
+				for _, line := range strings.Split(frontmatter, "\n") {
+					line = strings.TrimSpace(line)
+					if strings.HasPrefix(line, "name:") {
+						name = strings.TrimSpace(strings.TrimPrefix(line, "name:"))
+					} else if strings.HasPrefix(line, "description:") {
+						description = strings.TrimSpace(strings.TrimPrefix(line, "description:"))
+					}
+				}
+			}
+		}
+
+		skills = append(skills, map[string]interface{}{
+			"id":          entry.Name(),
+			"name":        name,
+			"description": description,
+			"path":        skillPath,
+		})
+	}
+
+	return skills
+}

--- a/v2/internal/composer/service.go
+++ b/v2/internal/composer/service.go
@@ -197,6 +197,19 @@ func (s *Service) Send(ctx context.Context, args SendArgs) (string, error) {
 			if directive := strings.TrimSpace(result.Output.Text); directive != "" && directive != strings.TrimSpace(args.Prompt) {
 				prompt = directive + "\n\n" + prompt
 			}
+			// Emit strategy metadata so the frontend can render it as a
+			// collapsible chip in the turn. Fires once per turn, before
+			// the CLI run starts.
+			s.emit("composer:event", Event{
+				PaneID:             args.PaneID,
+				TurnID:             turnID,
+				Type:               "strategy",
+				StrategyName:       result.Strategy.Name,
+				StrategyConfidence: result.Confidence,
+				TaskComplexity:     result.TaskContext.Complexity,
+				TaskRisk:           result.TaskContext.Risk,
+				BlastRadius:        result.Context.BlastRadius,
+			})
 		} else if err != nil {
 			// Surface but don't bypass — KISS, fail loud.
 			log.Warn("composer: orchestrator process failed", "err", err)
@@ -427,9 +440,14 @@ func (s *Service) run(ctx context.Context, cliPath string, args SendArgs, sessio
 		"--output-format", "stream-json",
 		"--verbose",
 		"--include-partial-messages",
+		"--include-hook-events",
 		"--permission-mode", "acceptEdits",
 		sessionFlag, sessionID,
 		"--model", args.Model,
+	}
+	// Effort level — "auto" or empty means "don't pass the flag" (default).
+	if args.Effort != "" && args.Effort != "auto" {
+		cliArgs = append(cliArgs, "--effort", args.Effort)
 	}
 	// "No project context" mode — strip every source of workspace awareness
 	// so the agent answers from its own knowledge only. Mirrors the legacy
@@ -652,22 +670,31 @@ func (s *Service) maybeRecordEdit(ctx context.Context, paneID, turnID, cwd, tool
 		if json.Unmarshal(input, &e) != nil || e.FilePath == "" {
 			return
 		}
-		old, _ := readFileSafe(e.FilePath)
-		// "new" content reconstruction is best-effort — for simple Edits we
-		// have the post-write file already on disk via fsnotify-style polling.
-		// v0: emit the file's *current* state as the new content.
+		// The CLI writes edits to disk before emitting tool_use, so the file
+		// already contains NewString. Reconstruct the pre-edit content by
+		// reversing the substitution.
 		newContent, _ := readFileSafe(e.FilePath)
+		old := strings.Replace(newContent, e.NewString, e.OldString, 1)
 		s.emitEdit(ctx, paneID, turnID, cwd, e.FilePath, old, newContent)
 
 	case "MultiEdit":
 		var m struct {
 			FilePath string `json:"file_path"`
+			Edits    []struct {
+				OldString string `json:"old_string"`
+				NewString string `json:"new_string"`
+			} `json:"edits"`
 		}
 		if json.Unmarshal(input, &m) != nil || m.FilePath == "" {
 			return
 		}
-		old, _ := readFileSafe(m.FilePath)
+		// File already has all edits applied. Reverse them in reverse order
+		// to reconstruct the original content.
 		newContent, _ := readFileSafe(m.FilePath)
+		old := newContent
+		for i := len(m.Edits) - 1; i >= 0; i-- {
+			old = strings.Replace(old, m.Edits[i].NewString, m.Edits[i].OldString, 1)
+		}
 		s.emitEdit(ctx, paneID, turnID, cwd, m.FilePath, old, newContent)
 	}
 }

--- a/v2/internal/composer/types.go
+++ b/v2/internal/composer/types.go
@@ -60,7 +60,7 @@ type Edit struct {
 type Event struct {
 	PaneID    string `json:"pane_id"`
 	TurnID    string `json:"turn_id,omitempty"`
-	Type      string `json:"type"` // "delta" | "thinking" | "tool_use" | "result" | "done" | "error"
+	Type      string `json:"type"` // "delta" | "thinking" | "tool_use" | "result" | "done" | "error" | "strategy"
 	Content   string `json:"content,omitempty"`
 	ToolName  string `json:"tool_name,omitempty"`
 	ToolInput string `json:"tool_input,omitempty"`
@@ -69,6 +69,15 @@ type Event struct {
 	InputTokens  int64   `json:"input_tokens,omitempty"`
 	OutputTokens int64   `json:"output_tokens,omitempty"`
 	CostUSD      float64 `json:"cost_usd,omitempty"`
+
+	// Strategy-specific fields, populated on type=="strategy".
+	// Emitted once per turn after the orchestrator selects a strategy,
+	// before the CLI run starts.
+	StrategyName       string  `json:"strategy_name,omitempty"`
+	StrategyConfidence float64 `json:"strategy_confidence,omitempty"`
+	TaskComplexity     string  `json:"task_complexity,omitempty"`
+	TaskRisk           string  `json:"task_risk,omitempty"`
+	BlastRadius        int     `json:"blast_radius,omitempty"`
 }
 
 // Mention is an `@file` reference passed alongside a prompt.
@@ -104,4 +113,7 @@ type SendArgs struct {
 	Model     string    `json:"model"`
 	Mentions  []Mention `json:"mentions"`
 	NoContext bool      `json:"no_context,omitempty"`
+	// Effort controls the reasoning effort level passed to the CLI via
+	// --effort <level>. Empty string means "don't pass the flag" (auto).
+	Effort    string    `json:"effort,omitempty"`
 }

--- a/web/app/components/AIEngineSection.tsx
+++ b/web/app/components/AIEngineSection.tsx
@@ -1,0 +1,222 @@
+"use client";
+// Author: Subash Karki
+
+import { motion } from "motion/react";
+import type { ReactNode } from "react";
+
+type Strategy = {
+  name: string;
+  desc: string;
+  icon: ReactNode;
+};
+
+const strategies: Strategy[] = [
+  {
+    name: "Direct",
+    desc: "Fast single-pass for simple tasks",
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="h-4 w-4">
+        <path d="M5 12h14M13 5l7 7-7 7" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+    ),
+  },
+  {
+    name: "Decompose",
+    desc: "Break complex goals into subtasks",
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="h-4 w-4">
+        <rect x="3" y="3" width="7" height="7" rx="1" />
+        <rect x="14" y="3" width="7" height="7" rx="1" />
+        <rect x="3" y="14" width="7" height="7" rx="1" />
+        <rect x="14" y="14" width="7" height="7" rx="1" />
+      </svg>
+    ),
+  },
+  {
+    name: "Advisor",
+    desc: "Expert consultation pattern",
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="h-4 w-4">
+        <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" strokeLinecap="round" />
+        <circle cx="12" cy="7" r="4" />
+      </svg>
+    ),
+  },
+  {
+    name: "Self-Refine",
+    desc: "Iterative self-improvement loop",
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="h-4 w-4">
+        <path d="M21 12a9 9 0 1 1-6.219-8.563" strokeLinecap="round" />
+        <path d="M21 3v6h-6" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+    ),
+  },
+  {
+    name: "Tree of Thought",
+    desc: "Branching exploration of solutions",
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="h-4 w-4">
+        <path d="M12 3v6M12 9l-6 6M12 9l6 6M6 15v3M18 15v3M12 9v9" strokeLinecap="round" />
+      </svg>
+    ),
+  },
+  {
+    name: "Debate",
+    desc: "Adversarial reasoning for robust answers",
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="h-4 w-4">
+        <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v10Z" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+    ),
+  },
+  {
+    name: "Graph of Thought",
+    desc: "Dependency-aware reasoning along code edges",
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="h-4 w-4">
+        <circle cx="5" cy="6" r="2" />
+        <circle cx="12" cy="12" r="2" />
+        <circle cx="19" cy="6" r="2" />
+        <circle cx="19" cy="18" r="2" />
+        <path d="M7 7l3 3M14 13l3 3M14 11l3-3" strokeLinecap="round" />
+      </svg>
+    ),
+  },
+  {
+    name: "Auto-Tune",
+    desc: "Learns which strategy works for your codebase",
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="h-4 w-4">
+        <path d="M12 2a4 4 0 0 1 4 4c0 1.95-1.4 3.58-3.25 3.93L12 22" strokeLinecap="round" />
+        <path d="M12 2a4 4 0 0 0-4 4c0 1.95 1.4 3.58 3.25 3.93" strokeLinecap="round" />
+      </svg>
+    ),
+  },
+];
+
+type SafetyFeature = {
+  title: string;
+  desc: string;
+  icon: ReactNode;
+  accent: string;
+};
+
+const safetyFeatures: SafetyFeature[] = [
+  {
+    title: "Dependency Graph",
+    desc: "Knows what breaks before you change it",
+    accent: "from-emerald-400/30 to-teal-400/10",
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="h-5 w-5">
+        <circle cx="12" cy="12" r="3" />
+        <circle cx="4" cy="4" r="2" />
+        <circle cx="20" cy="4" r="2" />
+        <circle cx="4" cy="20" r="2" />
+        <circle cx="20" cy="20" r="2" />
+        <path d="M6 6l3.5 3.5M18 6l-3.5 3.5M6 18l3.5-3.5M18 18l-3.5-3.5" strokeLinecap="round" />
+      </svg>
+    ),
+  },
+  {
+    title: "Hallucination Detection",
+    desc: "Verifies every file path the model references",
+    accent: "from-amber-400/30 to-orange-400/10",
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="h-5 w-5">
+        <path d="M12 9v4M12 17h.01" strokeLinecap="round" />
+        <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z" />
+      </svg>
+    ),
+  },
+  {
+    title: "PII Scanner",
+    desc: "Catches API keys and passwords before they leak",
+    accent: "from-red-400/30 to-rose-400/10",
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="h-5 w-5">
+        <rect x="3" y="11" width="18" height="11" rx="2" />
+        <path d="M7 11V7a5 5 0 0 1 10 0v4" strokeLinecap="round" />
+        <circle cx="12" cy="16" r="1" fill="currentColor" />
+      </svg>
+    ),
+  },
+];
+
+const AIEngineSection = () => {
+  return (
+    <section className="relative mx-auto w-full max-w-5xl px-6 py-24 sm:py-32">
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true, margin: "-100px" }}
+        transition={{ duration: 0.6 }}
+        className="mb-12 text-center"
+      >
+        <p className="mb-3 font-mono text-xs uppercase tracking-[0.2em] text-[var(--color-accent-violet)]">
+          AI Engine
+        </p>
+        <h2 className="text-3xl font-semibold tracking-tight sm:text-4xl md:text-5xl">
+          8 reasoning strategies.{" "}
+          <span className="text-gradient">One intelligent orchestrator.</span>
+        </h2>
+      </motion.div>
+
+      {/* Strategy grid */}
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        {strategies.map((s, i) => (
+          <motion.div
+            key={s.name}
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true, margin: "-50px" }}
+            transition={{ duration: 0.4, delay: i * 0.04 }}
+            whileHover={{ y: -3 }}
+            className="group relative overflow-hidden rounded-xl glass p-4"
+          >
+            <div
+              className="absolute -right-8 -top-8 h-24 w-24 rounded-full bg-gradient-to-br from-violet-400/15 to-fuchsia-400/5 blur-2xl opacity-0 transition-opacity duration-500 group-hover:opacity-100"
+              aria-hidden
+            />
+            <div className="relative">
+              <div className="mb-2 inline-flex h-7 w-7 items-center justify-center rounded-md border border-[var(--color-border)] bg-[var(--color-bg-elevated)] text-[var(--color-accent-violet)]">
+                {s.icon}
+              </div>
+              <h3 className="text-sm font-semibold">{s.name}</h3>
+              <p className="mt-1 text-xs leading-relaxed text-[var(--color-fg-muted)]">{s.desc}</p>
+            </div>
+          </motion.div>
+        ))}
+      </div>
+
+      {/* Safety features */}
+      <div className="mt-8 grid grid-cols-1 gap-4 sm:grid-cols-3">
+        {safetyFeatures.map((f, i) => (
+          <motion.div
+            key={f.title}
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true, margin: "-50px" }}
+            transition={{ duration: 0.5, delay: 0.3 + i * 0.08 }}
+            whileHover={{ y: -4 }}
+            className="group relative overflow-hidden rounded-2xl glass p-6"
+          >
+            <div
+              className={`absolute -right-12 -top-12 h-40 w-40 rounded-full bg-gradient-to-br ${f.accent} blur-2xl opacity-0 transition-opacity duration-500 group-hover:opacity-100`}
+              aria-hidden
+            />
+            <div className="relative">
+              <div className="mb-4 inline-flex h-10 w-10 items-center justify-center rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-elevated)] text-[var(--color-accent)]">
+                {f.icon}
+              </div>
+              <h3 className="text-lg font-semibold">{f.title}</h3>
+              <p className="mt-2 text-sm leading-relaxed text-[var(--color-fg-muted)]">{f.desc}</p>
+            </div>
+          </motion.div>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default AIEngineSection;

--- a/web/app/components/CodeShowcase.tsx
+++ b/web/app/components/CodeShowcase.tsx
@@ -1,4 +1,5 @@
 "use client";
+// Author: Subash Karki
 
 import { motion, useScroll, useTransform } from "motion/react";
 import { useRef } from "react";

--- a/web/app/components/ComparisonSection.tsx
+++ b/web/app/components/ComparisonSection.tsx
@@ -1,0 +1,150 @@
+"use client";
+// Author: Subash Karki
+
+import { motion } from "motion/react";
+
+type Row = {
+  feature: string;
+  phantom: string;
+  claudeCode: string;
+  cursor: string;
+  windsurf: string;
+};
+
+const rows: Row[] = [
+  {
+    feature: "Native desktop app",
+    phantom: "✓",
+    claudeCode: "Terminal",
+    cursor: "Fork of VS Code",
+    windsurf: "Fork of VS Code",
+  },
+  {
+    feature: "Multi-provider",
+    phantom: "✓",
+    claudeCode: "—",
+    cursor: "✓",
+    windsurf: "✓",
+  },
+  {
+    feature: "Dependency graph",
+    phantom: "✓",
+    claudeCode: "—",
+    cursor: "—",
+    windsurf: "—",
+  },
+  {
+    feature: "8 reasoning strategies",
+    phantom: "✓",
+    claudeCode: "—",
+    cursor: "—",
+    windsurf: "—",
+  },
+  {
+    feature: "PII / safety scanning",
+    phantom: "✓",
+    claudeCode: "—",
+    cursor: "—",
+    windsurf: "—",
+  },
+  {
+    feature: "Session cost tracking",
+    phantom: "✓",
+    claudeCode: "—",
+    cursor: "—",
+    windsurf: "—",
+  },
+  {
+    feature: "Gamification",
+    phantom: "✓",
+    claudeCode: "—",
+    cursor: "—",
+    windsurf: "—",
+  },
+  {
+    feature: "Hook system",
+    phantom: "✓",
+    claudeCode: "✓",
+    cursor: "—",
+    windsurf: "—",
+  },
+  {
+    feature: "Git worktree support",
+    phantom: "✓",
+    claudeCode: "Manual",
+    cursor: "Basic",
+    windsurf: "Basic",
+  },
+];
+
+const cellColor = (value: string) => {
+  if (value === "✓") return "text-emerald-400";
+  if (value === "—") return "text-[var(--color-fg-subtle)]";
+  return "text-[var(--color-fg-muted)]";
+};
+
+const ComparisonSection = () => {
+  return (
+    <section className="relative mx-auto w-full max-w-5xl px-6 py-24 sm:py-32">
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true, margin: "-100px" }}
+        transition={{ duration: 0.6 }}
+        className="mb-12 text-center"
+      >
+        <p className="mb-3 font-mono text-xs uppercase tracking-[0.2em] text-[var(--color-accent)]">
+          Compare
+        </p>
+        <h2 className="text-3xl font-semibold tracking-tight sm:text-4xl md:text-5xl">
+          How Phantom{" "}
+          <span className="text-gradient">stacks up.</span>
+        </h2>
+      </motion.div>
+
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true, margin: "-50px" }}
+        transition={{ duration: 0.6, delay: 0.1 }}
+        className="overflow-x-auto rounded-2xl glass"
+      >
+        <table className="w-full text-left text-sm">
+          <thead>
+            <tr className="border-b border-[var(--color-border)]/50">
+              <th className="px-6 py-4 font-medium text-[var(--color-fg-muted)]">Feature</th>
+              <th className="px-4 py-4 text-center font-semibold text-[var(--color-accent)]">Phantom</th>
+              <th className="px-4 py-4 text-center font-medium text-[var(--color-fg-muted)]">Claude Code</th>
+              <th className="px-4 py-4 text-center font-medium text-[var(--color-fg-muted)]">Cursor</th>
+              <th className="px-4 py-4 text-center font-medium text-[var(--color-fg-muted)]">Windsurf</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, i) => (
+              <tr
+                key={row.feature}
+                className={i < rows.length - 1 ? "border-b border-[var(--color-border-subtle)]/40" : ""}
+              >
+                <td className="px-6 py-3.5 font-medium">{row.feature}</td>
+                <td className={`px-4 py-3.5 text-center font-semibold ${cellColor(row.phantom)}`}>
+                  {row.phantom}
+                </td>
+                <td className={`px-4 py-3.5 text-center ${cellColor(row.claudeCode)}`}>
+                  {row.claudeCode}
+                </td>
+                <td className={`px-4 py-3.5 text-center ${cellColor(row.cursor)}`}>
+                  {row.cursor}
+                </td>
+                <td className={`px-4 py-3.5 text-center ${cellColor(row.windsurf)}`}>
+                  {row.windsurf}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </motion.div>
+    </section>
+  );
+};
+
+export default ComparisonSection;

--- a/web/app/components/ComposerShowcase.tsx
+++ b/web/app/components/ComposerShowcase.tsx
@@ -1,0 +1,161 @@
+"use client";
+// Author: Subash Karki
+
+import { motion } from "motion/react";
+import type { ReactNode } from "react";
+
+type ComposerFeature = {
+  title: string;
+  desc: string;
+  icon: ReactNode;
+};
+
+const features: ComposerFeature[] = [
+  {
+    title: "Session Cost Meter",
+    desc: "Running total of API spend per session",
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="h-5 w-5">
+        <path d="M12 2v20M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+    ),
+  },
+  {
+    title: "Context Window Gauge",
+    desc: "Color-coded progress bar shows context fullness",
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="h-5 w-5">
+        <rect x="3" y="8" width="18" height="8" rx="2" />
+        <rect x="5" y="10" width="8" height="4" rx="1" fill="currentColor" opacity="0.4" />
+      </svg>
+    ),
+  },
+  {
+    title: "Turn Efficiency",
+    desc: "Duration, tokens, cost, and files per turn",
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="h-5 w-5">
+        <circle cx="12" cy="12" r="10" />
+        <path d="M12 6v6l4 2" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+    ),
+  },
+  {
+    title: "Edit Card Review",
+    desc: "Accept or discard every file change with inline diff",
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="h-5 w-5">
+        <path d="M9 11l3 3L22 4" strokeLinecap="round" strokeLinejoin="round" />
+        <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+    ),
+  },
+  {
+    title: "Auto-Accept Mode",
+    desc: "One toggle to trust all edits",
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="h-5 w-5">
+        <rect x="1" y="5" width="22" height="14" rx="7" />
+        <circle cx="16" cy="12" r="4" fill="currentColor" opacity="0.4" />
+      </svg>
+    ),
+  },
+  {
+    title: "Model Picker",
+    desc: "Switch Sonnet, Opus, or Haiku mid-conversation",
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="h-5 w-5">
+        <path d="M4 6h16M4 12h16M4 18h16" strokeLinecap="round" />
+        <circle cx="8" cy="6" r="2" fill="currentColor" opacity="0.4" />
+        <circle cx="14" cy="12" r="2" fill="currentColor" opacity="0.4" />
+        <circle cx="10" cy="18" r="2" fill="currentColor" opacity="0.4" />
+      </svg>
+    ),
+  },
+  {
+    title: "Effort Control",
+    desc: "Tune reasoning depth: Low to Max",
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="h-5 w-5">
+        <path d="M12 2L2 7l10 5 10-5-10-5Z" />
+        <path d="M2 17l10 5 10-5M2 12l10 5 10-5" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+    ),
+  },
+  {
+    title: "Memory Viewer",
+    desc: "See exactly what context the model is working with",
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="h-5 w-5">
+        <path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7S2 12 2 12Z" />
+        <circle cx="12" cy="12" r="3" />
+      </svg>
+    ),
+  },
+];
+
+const ComposerShowcase = () => {
+  return (
+    <section className="relative mx-auto w-full max-w-5xl px-6 py-24 sm:py-32">
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true, margin: "-100px" }}
+        transition={{ duration: 0.6 }}
+        className="mb-12 text-center"
+      >
+        <p className="mb-3 font-mono text-xs uppercase tracking-[0.2em] text-[var(--color-accent)]">
+          Built-in composer
+        </p>
+        <h2 className="text-3xl font-semibold tracking-tight sm:text-4xl md:text-5xl">
+          AI coding, <span className="text-gradient">visualized.</span>
+        </h2>
+        <p className="mx-auto mt-4 max-w-2xl text-[var(--color-fg-muted)]">
+          Stream Claude&apos;s thinking in real-time. Review every edit. Track every token. Control
+          every model.
+        </p>
+      </motion.div>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {features.map((f, i) => (
+          <motion.div
+            key={f.title}
+            initial={{ opacity: 0, y: 30 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true, margin: "-50px" }}
+            transition={{ duration: 0.5, delay: i * 0.05 }}
+            whileHover={{ y: -4 }}
+            className="group relative overflow-hidden rounded-2xl glass p-5"
+          >
+            <div
+              className="absolute -right-12 -top-12 h-32 w-32 rounded-full bg-gradient-to-br from-cyan-400/20 to-sky-400/5 blur-2xl opacity-0 transition-opacity duration-500 group-hover:opacity-100"
+              aria-hidden
+            />
+            <div className="relative">
+              <div className="mb-3 inline-flex h-9 w-9 items-center justify-center rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-elevated)] text-[var(--color-accent)]">
+                {f.icon}
+              </div>
+              <h3 className="text-sm font-semibold">{f.title}</h3>
+              <p className="mt-1.5 text-xs leading-relaxed text-[var(--color-fg-muted)]">{f.desc}</p>
+            </div>
+          </motion.div>
+        ))}
+      </div>
+
+      <motion.div
+        initial={{ opacity: 0, y: 10 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true, margin: "-50px" }}
+        transition={{ duration: 0.5, delay: 0.4 }}
+        className="mt-8 text-center"
+      >
+        <span className="inline-flex items-center gap-2 rounded-full border border-[var(--color-border)] glass px-4 py-2 text-xs font-medium text-[var(--color-fg-muted)]">
+          <span className="h-1.5 w-1.5 rounded-full bg-[var(--color-accent)]" />
+          Works with Claude subscription or your own API key
+        </span>
+      </motion.div>
+    </section>
+  );
+};
+
+export default ComposerShowcase;

--- a/web/app/components/DownloadCTA.tsx
+++ b/web/app/components/DownloadCTA.tsx
@@ -1,0 +1,78 @@
+"use client";
+// Author: Subash Karki
+
+import { motion } from "motion/react";
+
+type Props = {
+  downloadUrl: string;
+  releaseTag?: string;
+  downloadSize?: string;
+  hasRelease: boolean;
+};
+
+const GITHUB_URL = "https://github.com/karki011/phantom";
+
+const DownloadCTA = ({ downloadUrl, releaseTag, downloadSize, hasRelease }: Props) => {
+  return (
+    <section className="relative mx-auto w-full max-w-5xl px-6 py-24 sm:py-32">
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true, margin: "-100px" }}
+        transition={{ duration: 0.6 }}
+        className="mx-auto max-w-2xl text-center"
+      >
+        <h2 className="text-3xl font-semibold tracking-tight sm:text-4xl md:text-5xl">
+          Download <span className="text-gradient">Phantom</span> for macOS
+        </h2>
+        <p className="mt-4 text-[var(--color-fg-muted)]">
+          Universal binary. Works on Apple Silicon and Intel.
+        </p>
+
+        <div className="mt-10 flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
+          {hasRelease ? (
+            <a
+              href={downloadUrl}
+              className="group relative inline-flex items-center gap-3 overflow-hidden rounded-xl bg-[var(--color-fg)] px-7 py-4 text-base font-semibold text-[var(--color-bg)] transition hover:scale-[1.02] active:scale-[0.99]"
+            >
+              <svg viewBox="0 0 24 24" fill="currentColor" className="h-5 w-5">
+                <path d="M17.05 20.28c-.98.95-2.05.8-3.08.35-1.09-.46-2.09-.48-3.24 0-1.44.62-2.2.44-3.06-.35C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09M12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25" />
+              </svg>
+              <span>Download for macOS</span>
+              {releaseTag && (
+                <span className="font-mono text-xs font-normal opacity-60">
+                  {releaseTag} {downloadSize ? `· ${downloadSize}` : ""}
+                </span>
+              )}
+            </a>
+          ) : (
+            <div className="inline-flex items-center gap-2 rounded-xl border border-[var(--color-border)] glass px-5 py-3 font-mono text-sm text-[var(--color-fg-muted)]">
+              <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-[var(--color-accent)]" />
+              Build coming soon
+            </div>
+          )}
+
+          <a
+            href={GITHUB_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 rounded-xl border border-[var(--color-border)] glass px-5 py-3.5 text-sm font-medium text-[var(--color-fg-muted)] transition hover:border-[var(--color-fg-subtle)] hover:text-[var(--color-fg)]"
+          >
+            <svg viewBox="0 0 24 24" fill="currentColor" className="h-5 w-5">
+              <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12Z" />
+            </svg>
+            View on GitHub
+          </a>
+        </div>
+      </motion.div>
+
+      {/* Bottom glow */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-x-16 -bottom-4 h-32 rounded-full bg-gradient-to-r from-sky-500/15 via-violet-500/15 to-pink-500/15 blur-3xl"
+      />
+    </section>
+  );
+};
+
+export default DownloadCTA;

--- a/web/app/components/FeatureGrid.tsx
+++ b/web/app/components/FeatureGrid.tsx
@@ -1,4 +1,5 @@
 "use client";
+// Author: Subash Karki
 
 import { motion } from "motion/react";
 import type { ReactNode } from "react";

--- a/web/app/components/GamificationTeaser.tsx
+++ b/web/app/components/GamificationTeaser.tsx
@@ -1,0 +1,50 @@
+"use client";
+// Author: Subash Karki
+
+import { motion } from "motion/react";
+
+const GamificationTeaser = () => {
+  return (
+    <section className="relative mx-auto w-full max-w-5xl px-6 py-24 sm:py-32">
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true, margin: "-100px" }}
+        transition={{ duration: 0.6 }}
+        className="mx-auto max-w-2xl text-center"
+      >
+        <p className="mb-3 font-mono text-xs uppercase tracking-[0.2em] text-[var(--color-accent-pink)]">
+          Gamification
+        </p>
+        <h2 className="text-3xl font-semibold tracking-tight sm:text-4xl md:text-5xl">
+          Ship code.{" "}
+          <span className="text-gradient">Level up.</span>
+        </h2>
+        <p className="mt-6 text-lg text-[var(--color-fg-muted)]">
+          XP system, daily quests, achievements, and rank progression. Because coding should feel
+          rewarding.
+        </p>
+
+        <div className="mt-10 flex flex-wrap items-center justify-center gap-3">
+          {["XP Tracking", "Daily Quests", "Achievements", "Rank Progression", "Leaderboard"].map(
+            (badge, i) => (
+              <motion.span
+                key={badge}
+                initial={{ opacity: 0, scale: 0.9 }}
+                whileInView={{ opacity: 1, scale: 1 }}
+                viewport={{ once: true }}
+                transition={{ duration: 0.3, delay: 0.3 + i * 0.06 }}
+                className="inline-flex items-center gap-1.5 rounded-full border border-[var(--color-border)] glass px-3.5 py-1.5 text-xs font-medium text-[var(--color-fg-muted)]"
+              >
+                <span className="h-1.5 w-1.5 rounded-full bg-[var(--color-accent-pink)]" />
+                {badge}
+              </motion.span>
+            ),
+          )}
+        </div>
+      </motion.div>
+    </section>
+  );
+};
+
+export default GamificationTeaser;

--- a/web/app/components/Hero3D.tsx
+++ b/web/app/components/Hero3D.tsx
@@ -1,4 +1,5 @@
 "use client";
+// Author: Subash Karki
 
 import dynamic from "next/dynamic";
 import { useEffect, useState } from "react";

--- a/web/app/components/HeroContent.tsx
+++ b/web/app/components/HeroContent.tsx
@@ -1,4 +1,5 @@
 "use client";
+// Author: Subash Karki
 
 import { motion } from "motion/react";
 
@@ -9,6 +10,8 @@ type Props = {
   downloadSize?: string;
   hasRelease: boolean;
 };
+
+const GITHUB_URL = "https://github.com/karki011/phantom";
 
 const HeroContent = ({ releaseTag, releaseDate, downloadUrl, downloadSize, hasRelease }: Props) => {
   return (
@@ -39,18 +42,27 @@ const HeroContent = ({ releaseTag, releaseDate, downloadUrl, downloadSize, hasRe
       <motion.p
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.7, delay: 0.25 }}
-        className="mt-7 max-w-xl text-lg text-[var(--color-fg-muted)] md:text-xl"
+        transition={{ duration: 0.7, delay: 0.2 }}
+        className="mt-5 text-xl font-medium text-[var(--color-fg)] sm:text-2xl"
       >
-        A native desktop workspace for developers. Terminal, editor, AI chat, git diff, and journal
-        — collapsed into one tabbed pane system.
+        The AI-native developer workspace.
+      </motion.p>
+
+      <motion.p
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.7, delay: 0.3 }}
+        className="mt-4 max-w-xl text-base text-[var(--color-fg-muted)] md:text-lg"
+      >
+        Terminal, editor, and AI composer in one window. Your code graph guides the model.
+        8 reasoning strategies. Built-in safety.
       </motion.p>
 
       <motion.div
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.7, delay: 0.4 }}
-        className="mt-10 flex flex-col items-center gap-3"
+        transition={{ duration: 0.7, delay: 0.45 }}
+        className="mt-10 flex flex-col items-center gap-3 sm:flex-row"
       >
         {hasRelease ? (
           <a
@@ -74,11 +86,17 @@ const HeroContent = ({ releaseTag, releaseDate, downloadUrl, downloadSize, hasRe
           </div>
         )}
 
-        <p className="font-mono text-xs text-[var(--color-fg-subtle)]">
-          Universal binary — works on Apple Silicon and Intel
-          {releaseDate ? ` · released ${releaseDate}` : ""}
-        </p>
       </motion.div>
+
+      <motion.p
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.5, delay: 0.6 }}
+        className="mt-4 font-mono text-xs text-[var(--color-fg-subtle)]"
+      >
+        Universal binary — works on Apple Silicon and Intel
+        {releaseDate ? ` · released ${releaseDate}` : ""}
+      </motion.p>
     </div>
   );
 };

--- a/web/app/components/PhantomScene.tsx
+++ b/web/app/components/PhantomScene.tsx
@@ -1,4 +1,5 @@
 "use client";
+// Author: Subash Karki
 
 import { Canvas, useFrame } from "@react-three/fiber";
 import { Float, MeshDistortMaterial, RoundedBox, Stars } from "@react-three/drei";

--- a/web/app/components/PricingSection.tsx
+++ b/web/app/components/PricingSection.tsx
@@ -1,0 +1,98 @@
+"use client";
+// Author: Subash Karki
+
+import { motion } from "motion/react";
+
+const PricingSection = () => {
+  return (
+    <section className="relative mx-auto w-full max-w-5xl px-6 py-24 sm:py-32">
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true, margin: "-100px" }}
+        transition={{ duration: 0.6 }}
+        className="mb-12 text-center"
+      >
+        <p className="mb-3 font-mono text-xs uppercase tracking-[0.2em] text-[var(--color-accent)]">
+          Pricing
+        </p>
+        <h2 className="text-3xl font-semibold tracking-tight sm:text-4xl md:text-5xl">
+          Free app.{" "}
+          <span className="text-gradient">Bring your model.</span>
+        </h2>
+      </motion.div>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        {/* Claude Subscription */}
+        <motion.div
+          initial={{ opacity: 0, x: -20 }}
+          whileInView={{ opacity: 1, x: 0 }}
+          viewport={{ once: true, margin: "-50px" }}
+          transition={{ duration: 0.5 }}
+          whileHover={{ y: -4 }}
+          className="group relative overflow-hidden rounded-2xl glass p-8"
+        >
+          <div
+            className="absolute -right-16 -top-16 h-48 w-48 rounded-full bg-gradient-to-br from-amber-400/20 to-orange-400/5 blur-3xl opacity-0 transition-opacity duration-500 group-hover:opacity-100"
+            aria-hidden
+          />
+          <div className="relative">
+            <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-[var(--color-border)] bg-[var(--color-bg-elevated)] px-3 py-1 text-xs font-medium text-[var(--color-fg-muted)]">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="h-3.5 w-3.5">
+                <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" strokeLinecap="round" />
+                <circle cx="12" cy="7" r="4" />
+              </svg>
+              Subscription
+            </div>
+            <h3 className="text-2xl font-semibold">Claude Subscription</h3>
+            <p className="mt-3 text-sm leading-relaxed text-[var(--color-fg-muted)]">
+              Already have Claude Max or Enterprise? Just log in. Zero config.
+              Flat monthly fee.
+            </p>
+          </div>
+        </motion.div>
+
+        {/* API Key (BYOK) */}
+        <motion.div
+          initial={{ opacity: 0, x: 20 }}
+          whileInView={{ opacity: 1, x: 0 }}
+          viewport={{ once: true, margin: "-50px" }}
+          transition={{ duration: 0.5, delay: 0.1 }}
+          whileHover={{ y: -4 }}
+          className="group relative overflow-hidden rounded-2xl glass p-8"
+        >
+          <div
+            className="absolute -right-16 -top-16 h-48 w-48 rounded-full bg-gradient-to-br from-cyan-400/20 to-sky-400/5 blur-3xl opacity-0 transition-opacity duration-500 group-hover:opacity-100"
+            aria-hidden
+          />
+          <div className="relative">
+            <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-[var(--color-border)] bg-[var(--color-bg-elevated)] px-3 py-1 text-xs font-medium text-[var(--color-fg-muted)]">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="h-3.5 w-3.5">
+                <path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777Zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+              BYOK
+            </div>
+            <h3 className="text-2xl font-semibold">API Key</h3>
+            <p className="mt-3 text-sm leading-relaxed text-[var(--color-fg-muted)]">
+              Use your own Anthropic API key. Stored in macOS Keychain.
+              Pay per token. Full cost visibility.
+            </p>
+          </div>
+        </motion.div>
+      </div>
+
+      <motion.p
+        initial={{ opacity: 0, y: 10 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true, margin: "-50px" }}
+        transition={{ duration: 0.5, delay: 0.3 }}
+        className="mt-6 text-center text-sm text-[var(--color-fg-subtle)]"
+      >
+        All Phantom features work with both options. The AI engine, graph intelligence,
+        hooks, and safety scanning are 100% local.
+      </motion.p>
+    </section>
+  );
+};
+
+export default PricingSection;

--- a/web/app/components/ProvidersSection.tsx
+++ b/web/app/components/ProvidersSection.tsx
@@ -1,0 +1,116 @@
+"use client";
+// Author: Subash Karki
+
+import { motion } from "motion/react";
+import type { ReactNode } from "react";
+
+type Provider = {
+  name: string;
+  desc: string;
+  icon: ReactNode;
+  accent: string;
+};
+
+const providers: Provider[] = [
+  {
+    name: "Claude",
+    desc: "Anthropic's reasoning model. Subscription or API key.",
+    accent: "from-amber-400/25 to-orange-400/5",
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" className="h-8 w-8">
+        <path
+          d="M16.5 3L12 13.5 7.5 3H3l9 18 9-18h-4.5Z"
+          fill="currentColor"
+          opacity="0.85"
+        />
+      </svg>
+    ),
+  },
+  {
+    name: "Codex",
+    desc: "OpenAI's agentic coding model. CLI integration.",
+    accent: "from-emerald-400/25 to-green-400/5",
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" className="h-8 w-8">
+        <circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="1.5" />
+        <path d="M12 7v5l3.5 3.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+    ),
+  },
+  {
+    name: "Gemini",
+    desc: "Google's multimodal model. CLI integration.",
+    accent: "from-sky-400/25 to-blue-400/5",
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" className="h-8 w-8">
+        <path
+          d="M12 2L4 7v10l8 5 8-5V7l-8-5Z"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinejoin="round"
+        />
+        <path d="M12 12l8-5M12 12v10M12 12L4 7" stroke="currentColor" strokeWidth="1.5" />
+      </svg>
+    ),
+  },
+];
+
+const ProvidersSection = () => {
+  return (
+    <section className="relative mx-auto w-full max-w-5xl px-6 py-24 sm:py-32">
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true, margin: "-100px" }}
+        transition={{ duration: 0.6 }}
+        className="mb-12 text-center"
+      >
+        <p className="mb-3 font-mono text-xs uppercase tracking-[0.2em] text-[var(--color-accent-pink)]">
+          Multi-provider
+        </p>
+        <h2 className="text-3xl font-semibold tracking-tight sm:text-4xl md:text-5xl">
+          Claude, Codex, or Gemini.{" "}
+          <span className="text-gradient">Your choice.</span>
+        </h2>
+      </motion.div>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        {providers.map((p, i) => (
+          <motion.div
+            key={p.name}
+            initial={{ opacity: 0, y: 30 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true, margin: "-50px" }}
+            transition={{ duration: 0.5, delay: i * 0.08 }}
+            whileHover={{ y: -4 }}
+            className="group relative overflow-hidden rounded-2xl glass p-8 text-center"
+          >
+            <div
+              className={`absolute -right-16 -top-16 h-48 w-48 rounded-full bg-gradient-to-br ${p.accent} blur-3xl opacity-0 transition-opacity duration-500 group-hover:opacity-100`}
+              aria-hidden
+            />
+            <div className="relative">
+              <div className="mx-auto mb-4 inline-flex h-14 w-14 items-center justify-center rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-elevated)] text-[var(--color-fg)]">
+                {p.icon}
+              </div>
+              <h3 className="text-xl font-semibold">{p.name}</h3>
+              <p className="mt-2 text-sm text-[var(--color-fg-muted)]">{p.desc}</p>
+            </div>
+          </motion.div>
+        ))}
+      </div>
+
+      <motion.p
+        initial={{ opacity: 0, y: 10 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true, margin: "-50px" }}
+        transition={{ duration: 0.5, delay: 0.3 }}
+        className="mt-6 text-center font-mono text-xs text-[var(--color-fg-subtle)]"
+      >
+        Add custom providers via YAML config
+      </motion.p>
+    </section>
+  );
+};
+
+export default ProvidersSection;

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,3 +1,4 @@
+// Author: Subash Karki
 import type { Metadata, Viewport } from "next";
 import { Inter, JetBrains_Mono } from "next/font/google";
 import "./globals.css";

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,6 +1,14 @@
+// Author: Subash Karki
 import Hero3D from "./components/Hero3D";
 import HeroContent from "./components/HeroContent";
+import ComposerShowcase from "./components/ComposerShowcase";
+import AIEngineSection from "./components/AIEngineSection";
 import FeatureGrid from "./components/FeatureGrid";
+import ProvidersSection from "./components/ProvidersSection";
+import PricingSection from "./components/PricingSection";
+import ComparisonSection from "./components/ComparisonSection";
+import GamificationTeaser from "./components/GamificationTeaser";
+import DownloadCTA from "./components/DownloadCTA";
 import CodeShowcase from "./components/CodeShowcase";
 
 type ReleaseAsset = {
@@ -54,6 +62,8 @@ const Page = async () => {
   const release = await fetchLatestRelease();
   const zipAsset = release?.assets.find((a) => a.name.endsWith(".zip"));
   const hasRelease = Boolean(zipAsset);
+  const downloadUrl = zipAsset ? zipAsset.browser_download_url : RELEASES_URL;
+  const downloadSize = zipAsset ? formatSize(zipAsset.size) : undefined;
 
   return (
     <>
@@ -63,11 +73,9 @@ const Page = async () => {
       <main className="relative">
         {/* HERO */}
         <section className="relative flex min-h-screen w-full items-center justify-center overflow-hidden px-6 pb-24 pt-16 sm:pt-20">
-          {/* 3D scene fills the section behind the text */}
           <div className="absolute inset-0 opacity-70 sm:opacity-90">
             <Hero3D />
           </div>
-          {/* Bottom gradient fade for legibility */}
           <div
             aria-hidden
             className="pointer-events-none absolute inset-x-0 bottom-0 h-48 bg-gradient-to-b from-transparent to-[var(--color-bg)]"
@@ -76,12 +84,11 @@ const Page = async () => {
             <HeroContent
               releaseTag={release?.tag_name}
               releaseDate={release?.published_at ? formatDate(release.published_at) : undefined}
-              downloadUrl={zipAsset ? zipAsset.browser_download_url : RELEASES_URL}
-              downloadSize={zipAsset ? formatSize(zipAsset.size) : undefined}
+              downloadUrl={downloadUrl}
+              downloadSize={downloadSize}
               hasRelease={hasRelease}
             />
           </div>
-          {/* Scroll cue */}
           <div className="pointer-events-none absolute bottom-6 left-1/2 z-10 -translate-x-1/2 text-[var(--color-fg-subtle)]">
             <div className="flex flex-col items-center gap-2 font-mono text-[10px] uppercase tracking-widest opacity-70">
               <span>scroll</span>
@@ -90,11 +97,37 @@ const Page = async () => {
           </div>
         </section>
 
-        {/* CODE SHOWCASE */}
+        {/* COMPOSER SHOWCASE */}
+        <ComposerShowcase />
+
+        {/* AI ENGINE */}
+        <AIEngineSection />
+
+        {/* SHARED CONTEXT */}
         <CodeShowcase />
 
-        {/* FEATURES */}
+        {/* WORKSPACE FEATURES */}
         <FeatureGrid />
+
+        {/* MULTI-PROVIDER */}
+        <ProvidersSection />
+
+        {/* PRICING */}
+        <PricingSection />
+
+        {/* COMPARISON */}
+        <ComparisonSection />
+
+        {/* GAMIFICATION */}
+        <GamificationTeaser />
+
+        {/* DOWNLOAD CTA */}
+        <DownloadCTA
+          downloadUrl={downloadUrl}
+          releaseTag={release?.tag_name}
+          downloadSize={downloadSize}
+          hasRelease={hasRelease}
+        />
 
         <div className="h-24" aria-hidden />
       </main>


### PR DESCRIPTION
## Summary

Comprehensive upgrade to the Composer pane, marketing site, and documentation — 30 files changed, ~2,500 lines added.

### Composer — Visual Polish
- Full markdown rendering (headings, code blocks, lists, tables, links, blockquotes)
- ASSISTANT/YOU badges with turn dividers
- Consistent 32px padding alignment across all sections
- Edit card buttons with filled green/red tints
- Sidebar expand button anchored to bottom

### Composer — Accountability Metrics
- Session cost meter (running total in status strip)
- Context window gauge (3px color-coded bar: accent → warning → danger)
- Turn efficiency cards (duration, tokens, cost, files, lines changed)

### Composer — New Controls
- Auto-accept toggle (hides Accept All when active)
- Effort level dropdown (Auto/Low/Medium/High/Max)
- Tip tooltips on all toolbar icon buttons

### Composer — New Panels
- Memory viewer right rail (loaded CLAUDE.md + rules with sizes)
- Skill browser right rail (.claude/skills/ with search + invoke)

### Composer — Intelligence Visibility
- Strategy visualization (orchestrator strategy, confidence, complexity, risk, blast radius)
- Tool call status dots (blinking → green → red)
- Thinking blocks collapsed by default
- Hook events via --include-hook-events flag

### Go Backend
- Fixed -0 +0 edit diff race condition (reconstruct old by reversing substitution)
- ComposerGetMemoryContext + ComposerListSkills bindings
- Strategy event emission from orchestrator
- Effort flag passthrough

### Marketing Site (web/)
- 7 new sections: Composer Showcase, AI Engine, Multi-Provider, Pricing (Subscription vs BYOK), Comparison Table, Gamification, Download CTA
- Updated hero copy

### Docs
- README rewrite covering all features
- Fixed "Electron" → "Wails" in docs/index.html

## Fun fact
This entire PR was built by spawning 20+ parallel AI agents across a single session — research agents for UX audit and Claude Code analysis, then implementation agents for CSS, Go, SolidJS, and Next.js, all working on separate files simultaneously.

## Test plan
- [ ] `wails dev` — verify Composer renders with all new UI elements
- [ ] Send a prompt — verify strategy block, tool dots, turn metrics appear
- [ ] Toggle auto-accept — verify edit cards auto-accept and Accept All hides
- [ ] Open Memory panel (book icon) — verify CLAUDE.md files listed
- [ ] Open Skills panel (zap icon) — verify skills listed with invoke
- [ ] Switch effort dropdown — verify label shows correctly
- [ ] `cd web && pnpm dev` — verify landing page renders all 9 sections
- [ ] `go build ./...` — verify Go compiles