### PR TITLE
fix: fetch first release with assets, reduce revalidate to 5min

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -32,14 +32,15 @@ const RELEASES_URL = `https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}/releases
 const fetchLatestRelease = async (): Promise<LatestRelease | null> => {
   try {
     const res = await fetch(
-      `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/releases/latest`,
+      `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/releases`,
       {
-        next: { revalidate: 3600 },
+        next: { revalidate: 300 },
         headers: { Accept: "application/vnd.github+json" },
       },
     );
     if (!res.ok) return null;
-    return (await res.json()) as LatestRelease;
+    const releases = (await res.json()) as LatestRelease[];
+    return releases.find((r) => r.assets.length > 0) ?? releases[0] ?? null;
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary
- Fetch `/releases` instead of `/releases/latest` and pick the first release with downloadable assets
- Reduces ISR revalidate from 1h to 5min so new builds show up faster
- Fixes "Build coming soon" showing when latest release has no assets yet (build in progress)