### PR TITLE
ix: remove domain-link step, fix worktree refresh, improve composer errors

### DIFF
--- a/v2/frontend/src/components/panes/ComposerPane.tsx
+++ b/v2/frontend/src/components/panes/ComposerPane.tsx
@@ -425,17 +425,18 @@ export default function ComposerPane(props: ComposerPaneProps) {
     setInput('');
     scrollToBottom();
 
-    const newId = await composerSend(paneId(), prompt, cwd(), model(), mentions(), noContext(), effort());
-    if (!newId) {
+    const result = await composerSend(paneId(), prompt, cwd(), model(), mentions(), noContext(), effort());
+    if (!result.id) {
+      const errMsg = result.error ?? 'Failed to start. Make sure the Claude CLI is installed and accessible.';
       setTurns((prev) =>
-        prev.map((t) => (t.id === turnId ? { ...t, status: 'error', error: 'Failed to send' } : t)),
+        prev.map((t) => (t.id === turnId ? { ...t, status: 'error', error: errMsg } : t)),
       );
       setRunning(false);
       return;
     }
     // Re-key the turn to the server-assigned ID so stream events route correctly.
-    setTurns((prev) => prev.map((t) => (t.id === turnId ? { ...t, id: newId } : t)));
-    setActiveTurnId(newId);
+    setTurns((prev) => prev.map((t) => (t.id === turnId ? { ...t, id: result.id } : t)));
+    setActiveTurnId(result.id);
     setMentions([]);
   };
 

--- a/v2/frontend/src/core/bindings/composer.ts
+++ b/v2/frontend/src/core/bindings/composer.ts
@@ -59,12 +59,12 @@ export async function composerSend(
   mentions: ComposerMention[],
   noContext = false,
   effort = '',
-): Promise<string> {
+): Promise<{ id: string; error?: string }> {
   try {
     const id = await App()?.ComposerSend(paneId, prompt, cwd, model, mentions, noContext, effort);
-    return typeof id === 'string' ? id : '';
-  } catch {
-    return '';
+    return { id: typeof id === 'string' ? id : '' };
+  } catch (e) {
+    return { id: '', error: e instanceof Error ? e.message : String(e) };
   }
 }
 

--- a/v2/frontend/src/core/signals/worktrees.ts
+++ b/v2/frontend/src/core/signals/worktrees.ts
@@ -3,7 +3,7 @@
 
 import { createSignal, createMemo } from 'solid-js';
 import { onWailsEvent } from '../events';
-import { projects, bootstrapProjects } from './projects';
+import { projects, bootstrapProjects, refreshProjects } from './projects';
 import { activeWorktreeId, setActiveWorktreeId } from './app';
 import { listWorktrees, createWorktree, removeWorktree, getAllWorktreeStatus } from '../bindings';
 import { setPref, loadPref } from './preferences';
@@ -208,6 +208,10 @@ export async function bootstrapWorktrees(): Promise<void> {
   onWailsEvent('git:branch-changed', () => {
     refreshAllWorktrees();
     refreshAllWorktreeStatuses();
+  });
+  onWailsEvent('project:created', async () => {
+    await refreshProjects();
+    await refreshAllWorktrees();
   });
 }
 

--- a/v2/frontend/src/screens/onboarding/OnboardingFlow.tsx
+++ b/v2/frontend/src/screens/onboarding/OnboardingFlow.tsx
@@ -11,7 +11,6 @@ import { BootTerminal } from './phases/BootTerminal';
 import { DepsCheck } from './phases/DepsCheck';
 import { IdentityBind } from './phases/IdentityBind';
 import { DomainSelect } from './phases/DomainSelect';
-import { DomainLink } from './phases/DomainLink';
 import { AIEngineConsent } from './phases/AIEngineConsent';
 import { AbilityAwaken } from './phases/AbilityAwaken';
 import { Awakening } from './phases/Awakening';
@@ -96,9 +95,6 @@ export function OnboardingFlow(props: OnboardingFlowProps) {
             <Match when={phase() === 'domain-select'}>
               <DomainSelect onComplete={handlePhaseComplete} />
             </Match>
-            <Match when={phase() === 'domain-link'}>
-              <DomainLink onComplete={handlePhaseComplete} />
-            </Match>
             <Match when={phase() === 'ai-engine'}>
               <AIEngineConsent onComplete={handlePhaseComplete} />
             </Match>
@@ -115,7 +111,7 @@ export function OnboardingFlow(props: OnboardingFlowProps) {
 
       <Show when={isMiddlePhase()}>
         <div class={styles.progressBar}>
-          <HexProgress total={6} current={completedPhases()} />
+          <HexProgress total={5} current={completedPhases()} />
         </div>
       </Show>
     </div>

--- a/v2/frontend/src/screens/onboarding/config/phases.ts
+++ b/v2/frontend/src/screens/onboarding/config/phases.ts
@@ -8,7 +8,6 @@ export const phaseOrder: PhaseId[] = [
   'deps-check',
   'identity-bind',
   'domain-select',
-  'domain-link',
   'ai-engine',
   'ability-awaken',
   'complete',

--- a/v2/internal/app/bindings_composer.go
+++ b/v2/internal/app/bindings_composer.go
@@ -22,10 +22,10 @@ import (
 //
 // effort controls the reasoning effort level ("low", "medium", "high", "max").
 // Empty string means "don't pass the flag" (auto/default).
-func (a *App) ComposerSend(paneID, prompt, cwd, model string, mentions []composer.Mention, noContext bool, effort string) string {
+func (a *App) ComposerSend(paneID, prompt, cwd, model string, mentions []composer.Mention, noContext bool, effort string) (string, error) {
 	if a.Composer == nil {
 		slog.Warn("ComposerSend: composer service not initialised")
-		return ""
+		return "", fmt.Errorf("Composer service is not available")
 	}
 	id, err := a.Composer.Send(a.ctx, composer.SendArgs{
 		PaneID:    paneID,
@@ -34,13 +34,13 @@ func (a *App) ComposerSend(paneID, prompt, cwd, model string, mentions []compose
 		Model:     model,
 		Mentions:  mentions,
 		NoContext: noContext,
-		Effort:   effort,
+		Effort:    effort,
 	})
 	if err != nil {
 		slog.Error("ComposerSend failed", "pane", paneID, "err", err)
-		return ""
+		return "", err
 	}
-	return id
+	return id, nil
 }
 
 // ComposerCancel stops the active run on a pane (no-op if nothing running).

--- a/v2/internal/app/bindings_projects.go
+++ b/v2/internal/app/bindings_projects.go
@@ -18,6 +18,7 @@ import (
 	"github.com/subashkarki/phantom-os-v2/internal/git"
 	"github.com/subashkarki/phantom-os-v2/internal/integration"
 	"github.com/subashkarki/phantom-os-v2/internal/project"
+	wailsRuntime "github.com/wailsapp/wails/v2/pkg/runtime"
 )
 
 // GetProjects returns all registered projects.
@@ -99,6 +100,8 @@ func (a *App) AddProject(repoPath string) (*db.Project, error) {
 	if err := integration.EnsureProjectHasMCP(repoPath); err != nil {
 		slog.Warn("AddProject: ensure mcp project enablement failed", "err", err)
 	}
+
+	wailsRuntime.EventsEmit(a.ctx, "project:created", proj.ID)
 
 	return &proj, nil
 }

--- a/v2/internal/composer/service.go
+++ b/v2/internal/composer/service.go
@@ -561,12 +561,12 @@ func (s *Service) run(ctx context.Context, cliPath string, args SendArgs, sessio
 	}
 
 	if err := cmd.Wait(); err != nil && ctx.Err() == nil {
-		errMsg := stderrBuf.String()
+		errMsg := strings.TrimSpace(stderrBuf.String())
 		if errMsg == "" {
 			errMsg = err.Error()
 		}
 		log.Warn("composer: cli wait", "err", err)
-		s.emit("composer:event", Event{PaneID: args.PaneID, TurnID: turnID, Type: "error", Content: errMsg})
+		s.emit("composer:event", Event{PaneID: args.PaneID, TurnID: turnID, Type: "error", Content: friendlyComposerError(errMsg)})
 		s.markTurnError(ctx, turnID)
 		return
 	}
@@ -593,6 +593,24 @@ func (s *Service) run(ctx context.Context, cliPath string, args SendArgs, sessio
 		OutputTokens: totalOut,
 		CostUSD:      totalCost,
 	})
+}
+
+// friendlyComposerError translates raw claude CLI error output into
+// user-readable messages for common failure modes.
+func friendlyComposerError(raw string) string {
+	lower := strings.ToLower(raw)
+	switch {
+	case strings.Contains(lower, "connectionrefused") || strings.Contains(lower, "connection refused"):
+		return "Unable to connect to the Anthropic API. Check your internet connection and API key, then try again."
+	case strings.Contains(lower, "401") || strings.Contains(lower, "unauthorized") || strings.Contains(lower, "authentication"):
+		return "Authentication failed. Check your ANTHROPIC_API_KEY or run `claude login`."
+	case strings.Contains(lower, "429") || strings.Contains(lower, "rate limit"):
+		return "Rate limit reached. Please wait a moment before trying again."
+	case strings.Contains(lower, "context deadline exceeded") || strings.Contains(lower, "timeout"):
+		return "The request timed out. Try again in a moment."
+	default:
+		return raw
+	}
 }
 
 // handleAssistant unpacks an "assistant" event's content blocks into stream


### PR DESCRIPTION


- Remove LINK YOUR DOMAIN onboarding phase (DomainLink) — no user value
- Emit project:created Wails event from AddProject so frontend reactively refreshes worktrees/branches without requiring an app restart
- Subscribe to project:created in bootstrapWorktrees to call refreshProjects
  + refreshAllWorktrees on any project add
- Change ComposerSend to return (string, error) so JS receives the actual failure reason instead of a silent empty string
- Update composerSend binding to surface error message via { id, error? }
- Replace generic "Failed to send" fallback with the real error message
- Add friendlyComposerError() helper in service.go to translate raw CLI errors (ConnectionRefused, 401, 429, timeout) into actionable messages

Fixes #32