### PR TITLE
feat(v2): server log ring, header drawer, and pin mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,18 @@ cd v2 && make docs-llm
 
 This is an early-stage project. Issues and PRs welcome — but expect things to move fast and break.
 
+### Commit messages (semver + changelog)
+
+[Conventional Commits](https://www.conventionalcommits.org/) drive **release-please** updates to `CHANGELOG.md` and version bumps:
+
+| Bump   | When to use | Example subject |
+|--------|----------------|-----------------|
+| **patch** | fixes | `fix(v2): close server log drawer on escape` |
+| **minor** | new behavior, backward compatible | `feat(v2): export server log to file` |
+| **major** | breaking API / behavior | `feat(v2)!: rename GetRecentAppLogs` or a body line `BREAKING CHANGE: …` |
+
+Use **`feat`**, **`fix`**, **`perf`**, **`docs`**, etc., with an optional scope like **`(v2)`**. Squash-merge PRs with **one** conventional title so `main` history stays clean for the bot.
+
 ## License
 
 TBD.

--- a/v2/frontend/src/components/layout/AppBackendLogDrawer.css.ts
+++ b/v2/frontend/src/components/layout/AppBackendLogDrawer.css.ts
@@ -1,0 +1,39 @@
+// Phantom — Server log drawer body
+// Author: Subash Karki
+
+import { style } from '@vanilla-extract/css';
+import { vars } from '@/styles/theme.css';
+
+export const root = style({
+  display: 'flex',
+  flexDirection: 'column',
+  flex: 1,
+  minHeight: 0,
+  padding: vars.space.md,
+  boxSizing: 'border-box',
+});
+
+export const hint = style({
+  fontFamily: vars.font.mono,
+  fontSize: vars.fontSize.xs,
+  color: vars.color.textDisabled,
+  margin: `0 0 ${vars.space.sm}`,
+  flexShrink: 0,
+});
+
+export const pre = style({
+  margin: 0,
+  flex: 1,
+  minHeight: 0,
+  overflow: 'auto',
+  padding: vars.space.sm,
+  fontFamily: vars.font.mono,
+  fontSize: '11px',
+  lineHeight: 1.45,
+  color: vars.color.textSecondary,
+  backgroundColor: vars.color.bgSecondary,
+  border: `1px solid ${vars.color.border}`,
+  borderRadius: vars.radius.md,
+  whiteSpace: 'pre-wrap',
+  wordBreak: 'break-word',
+});

--- a/v2/frontend/src/components/layout/AppBackendLogDrawer.tsx
+++ b/v2/frontend/src/components/layout/AppBackendLogDrawer.tsx
@@ -1,0 +1,52 @@
+// Phantom — Live server log lines for the header drawer
+// Author: Subash Karki
+
+import { createEffect, createSignal, onCleanup, type Accessor, type JSX } from 'solid-js';
+import { getRecentAppLogs } from '@/core/bindings/applog';
+import * as styles from './AppBackendLogDrawer.css';
+
+export interface AppBackendLogDrawerProps {
+  open: Accessor<boolean>;
+}
+
+export function AppBackendLogDrawer(props: AppBackendLogDrawerProps): JSX.Element {
+  const [logLines, setLogLines] = createSignal<string[]>([]);
+  let logPreEl: HTMLPreElement | undefined;
+
+  const pull = async () => {
+    setLogLines(await getRecentAppLogs(50));
+  };
+
+  createEffect(() => {
+    if (!props.open()) return;
+    void pull();
+    const id = setInterval(() => void pull(), 2000);
+    onCleanup(() => clearInterval(id));
+  });
+
+  createEffect(() => {
+    logLines();
+    const el = logPreEl;
+    if (el) {
+      requestAnimationFrame(() => {
+        el.scrollTop = el.scrollHeight;
+      });
+    }
+  });
+
+  return (
+    <div class={styles.root}>
+      <p class={styles.hint}>
+        Last 50 lines · refreshes every 2s while open · pin the header so clicks outside do not close this drawer
+      </p>
+      <pre
+        class={styles.pre}
+        ref={(el) => {
+          logPreEl = el ?? undefined;
+        }}
+      >
+        {logLines().length > 0 ? logLines().join('\n') : 'No log lines yet.'}
+      </pre>
+    </div>
+  );
+}

--- a/v2/frontend/src/components/layout/WindowDragStrip.tsx
+++ b/v2/frontend/src/components/layout/WindowDragStrip.tsx
@@ -1,7 +1,9 @@
 // Phantom — Draggable strip housing macOS traffic-light inset, nav history, primary tab toggle, system stats, and action icons
 // Author: Subash Karki
 
-import { createMemo, onCleanup, onMount, Show } from 'solid-js';
+import type { Accessor } from 'solid-js';
+import { createMemo, createSignal, onCleanup, onMount, Show } from 'solid-js';
+import { Pin } from 'lucide-solid';
 import { APP_NAME } from '@/core/branding';
 import {
   activeTopTab,
@@ -20,13 +22,16 @@ import {
 import { openSettings } from '@/core/signals/settings';
 import { openAICommandCenter, aiCommandCenterSeen } from '@/core/signals/ai-command-center';
 import { toggleDocs } from '@/core/signals/docs';
-import { focusOrCreateTab, addTab } from '@/core/panes/signals';
+import { focusOrCreateTab } from '@/core/panes/signals';
 import { toggleCommandPalette } from '@/core/signals/command-palette';
 import { requestShutdown } from '@/core/signals/shutdown';
 import { gamificationEnabled, hunterProfile, dailyQuests } from '@/core/signals/gamification';
 import { RankBadge } from '@/shared/Gamification/RankBadge';
 import { XPProgressBar } from '@/shared/Gamification/XPProgressBar';
 import { Tip } from '@/shared/Tip/Tip';
+import { PhantomDrawer } from '@/shared/PhantomDrawer/PhantomDrawer';
+import * as drawerStyles from '@/shared/PhantomDrawer/PhantomDrawer.css';
+import { AppBackendLogDrawer } from './AppBackendLogDrawer';
 import { ChevronLeft, ChevronRight, SystemIcon, FolderIcon } from './header-icons';
 import * as shellStyles from '@/styles/app-shell.css';
 import * as gamStyles from '@/styles/gamification.css';
@@ -68,12 +73,11 @@ function JournalIcon() {
   );
 }
 
-function TerminalIcon() {
+function LogIcon() {
   return (
-    <svg width="14" height="14" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-      <rect x="1.5" y="2.5" width="13" height="11" rx="2" stroke="currentColor" stroke-width="1.4" />
-      <path d="M4 6l2.5 2L4 10" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" />
-      <path d="M8 10h4" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" />
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8l-6-6Z" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
+      <path d="M14 2v6h6M8 13h8M8 17h8M8 9h4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
     </svg>
   );
 }
@@ -97,6 +101,31 @@ function PowerIcon() {
   );
 }
 
+function ServerLogPinButton(props: {
+  pinned: Accessor<boolean>;
+  onToggle: () => void;
+}) {
+  return (
+    <Tip
+      label="Pin: keep server log open without blocking the app. Click again to unpin."
+      placement="bottom"
+    >
+      <button
+        type="button"
+        class={`${drawerStyles.pinToggle} ${props.pinned() ? drawerStyles.pinToggleActive : ''}`}
+        aria-pressed={props.pinned()}
+        aria-label={props.pinned() ? 'Unpin server log' : 'Pin server log'}
+        onClick={(e) => {
+          e.preventDefault();
+          props.onToggle();
+        }}
+      >
+        <Pin size={16} />
+      </button>
+    </Tip>
+  );
+}
+
 export function WindowDragStrip() {
   onMount(() => {
     startSystemStatsPoll();
@@ -115,6 +144,8 @@ export function WindowDragStrip() {
   });
 
   const stats = systemStats;
+  const [backendLogOpen, setBackendLogOpen] = createSignal(false);
+  const [backendLogPinned, setBackendLogPinned] = createSignal(false);
 
   return (
     <div class={shellStyles.windowDragStrip}>
@@ -192,9 +223,15 @@ export function WindowDragStrip() {
 
       <div class={shellStyles.windowDragStripRight}>
         <div class={shellStyles.headerActions}>
-          <Tip label="Terminal" placement="bottom">
-            <button data-tour="action-terminal" class={shellStyles.headerIconButton} type="button" aria-label="Open terminal" onClick={() => addTab('terminal')}>
-              <TerminalIcon />
+          <Tip label="Server log" placement="bottom">
+            <button
+              data-tour="action-server-log"
+              class={shellStyles.headerIconButton}
+              type="button"
+              aria-label="Open server log"
+              onClick={() => setBackendLogOpen(true)}
+            >
+              <LogIcon />
             </button>
           </Tip>
           <Tip label="Command Palette" placement="bottom">
@@ -286,6 +323,24 @@ export function WindowDragStrip() {
           </Show>
         </Show>
       </div>
+
+      <PhantomDrawer
+        open={backendLogOpen}
+        onOpenChange={(open) => {
+          setBackendLogOpen(open);
+          if (!open) setBackendLogPinned(false);
+        }}
+        title="Server log"
+        modal={() => !backendLogPinned()}
+        headerTrailing={
+          <ServerLogPinButton
+            pinned={backendLogPinned}
+            onToggle={() => setBackendLogPinned((p) => !p)}
+          />
+        }
+      >
+        <AppBackendLogDrawer open={backendLogOpen} />
+      </PhantomDrawer>
     </div>
   );
 }

--- a/v2/frontend/src/core/bindings/applog.ts
+++ b/v2/frontend/src/core/bindings/applog.ts
@@ -1,0 +1,12 @@
+// Author: Subash Karki
+
+const App = () => (window as any).go?.['app']?.App;
+
+export async function getRecentAppLogs(maxLines = 50): Promise<string[]> {
+  try {
+    const lines = await App()?.GetRecentAppLogs(maxLines);
+    return Array.isArray(lines) ? lines : [];
+  } catch {
+    return [];
+  }
+}

--- a/v2/frontend/src/core/tour/steps.ts
+++ b/v2/frontend/src/core/tour/steps.ts
@@ -53,9 +53,9 @@ export const TOUR_STEPS: TourStep[] = [
     align: 'center',
   },
   {
-    element: '[data-tour="action-terminal"]',
-    title: '[SYSTEM] Terminal',
-    description: 'Spin up a new terminal pane in the workspace.',
+    element: '[data-tour="action-server-log"]',
+    title: '[SYSTEM] Server log',
+    description: 'Recent server log lines — same output as the running process, in a side drawer. Pin to keep it open while you work.',
     side: 'bottom',
     align: 'end',
   },

--- a/v2/frontend/src/env.d.ts
+++ b/v2/frontend/src/env.d.ts
@@ -43,6 +43,7 @@ interface Window {
         QuitApp(): Promise<void>;
         FactoryResetLocalData(confirmation: string): Promise<void>;
         GetShutdownStats(): Promise<{ session_count: number; total_tokens: number; total_cost: number; uptime: string }>;
+        GetRecentAppLogs(maxLines: number): Promise<string[]>;
         GetFileGraphStats(projectID: string): Promise<{ indexed: boolean; indexing: boolean; files: number; symbols: number; edges: number }>;
         StartFileGraph(projectID: string): Promise<{ started?: boolean; error?: string; project?: string }>;
         StopFileGraph(projectID: string): Promise<void>;

--- a/v2/frontend/src/screens/system/ResourceMonitorPanel.tsx
+++ b/v2/frontend/src/screens/system/ResourceMonitorPanel.tsx
@@ -4,7 +4,6 @@
 import {
   createSignal,
   createMemo,
-  createEffect,
   onMount,
   onCleanup,
   Show,

--- a/v2/frontend/src/shared/PhantomDrawer/PhantomDrawer.css.ts
+++ b/v2/frontend/src/shared/PhantomDrawer/PhantomDrawer.css.ts
@@ -70,6 +70,38 @@ export const title = style({
   fontWeight: 700,
   margin: 0,
   flex: 1,
+  minWidth: 0,
+});
+
+export const headerTrailingWrap = style({
+  display: 'flex',
+  alignItems: 'center',
+  flexShrink: 0,
+});
+
+export const pinToggle = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '28px',
+  height: '28px',
+  borderRadius: vars.radius.sm,
+  border: `1px solid ${vars.color.border}`,
+  background: 'transparent',
+  color: vars.color.textDisabled,
+  cursor: 'pointer',
+  flexShrink: 0,
+  transition: 'all 150ms ease',
+  ':hover': {
+    color: vars.color.textPrimary,
+    background: vars.color.bgHover,
+  },
+});
+
+export const pinToggleActive = style({
+  color: vars.color.accent,
+  borderColor: `color-mix(in srgb, ${vars.color.accent} 45%, ${vars.color.border})`,
+  background: `color-mix(in srgb, ${vars.color.accent} 12%, transparent)`,
 });
 
 export const closeButton = style({
@@ -93,5 +125,8 @@ export const closeButton = style({
 
 export const body = style({
   flex: 1,
+  minHeight: 0,
   overflow: 'hidden',
+  display: 'flex',
+  flexDirection: 'column',
 });

--- a/v2/frontend/src/shared/PhantomDrawer/PhantomDrawer.tsx
+++ b/v2/frontend/src/shared/PhantomDrawer/PhantomDrawer.tsx
@@ -1,7 +1,9 @@
-// Phantom — Right-side drawer component
+// Phantom — Right-side drawer component (Kobalte Dialog — modal / non-modal, see
+// https://kobalte.dev/docs/core/components/dialog/#api-reference )
 // Author: Subash Karki
 
 import type { Accessor, JSX } from 'solid-js';
+import { Show, createMemo } from 'solid-js';
 import { X } from 'lucide-solid';
 import { Dialog } from '@kobalte/core/dialog';
 import * as styles from './PhantomDrawer.css';
@@ -11,16 +13,45 @@ interface PhantomDrawerProps {
   onOpenChange: (open: boolean) => void;
   title: string;
   children: JSX.Element;
+  /** When false, the page behind stays interactive (Kobalte `modal={false}`). Default: always modal. */
+  modal?: Accessor<boolean>;
+  /** Optional controls between title and close (e.g. pin). */
+  headerTrailing?: JSX.Element;
 }
 
 export function PhantomDrawer(props: PhantomDrawerProps) {
+  const isModal = createMemo(() => props.modal?.() ?? true);
+
   return (
-    <Dialog open={props.open()} onOpenChange={props.onOpenChange}>
+    <Dialog
+      open={props.open()}
+      onOpenChange={props.onOpenChange}
+      modal={isModal()}
+      // Kobalte: scroll can stay locked when modal=false unless explicitly disabled.
+      preventScroll={isModal() ? undefined : false}
+    >
       <Dialog.Portal>
-        <Dialog.Overlay class={styles.overlay} />
-        <Dialog.Content class={styles.panel}>
+        <Show when={isModal()}>
+          <Dialog.Overlay class={styles.overlay} />
+        </Show>
+        <Dialog.Content
+          class={styles.panel}
+          // Kobalte: preventDefault on outside interaction stops dismiss while non-modal (pinned).
+          onPointerDownOutside={(e) => {
+            if (!isModal()) e.preventDefault();
+          }}
+          onInteractOutside={(e) => {
+            if (!isModal()) e.preventDefault();
+          }}
+          onFocusOutside={(e) => {
+            if (!isModal()) e.preventDefault();
+          }}
+        >
           <div class={styles.header}>
             <Dialog.Title class={styles.title}>{props.title}</Dialog.Title>
+            <Show when={props.headerTrailing}>
+              <div class={styles.headerTrailingWrap}>{props.headerTrailing}</div>
+            </Show>
             <Dialog.CloseButton class={styles.closeButton}>
               <X size={16} />
             </Dialog.CloseButton>

--- a/v2/internal/app/bindings_applog.go
+++ b/v2/internal/app/bindings_applog.go
@@ -1,0 +1,16 @@
+// Author: Subash Karki
+package app
+
+import "github.com/subashkarki/phantom-os-v2/internal/applog"
+
+// GetRecentAppLogs returns the last log lines captured from backend logging (stdlib,
+// charmbracelet/log, and slog). maxLines is clamped to [1, 500]; default 50.
+func (a *App) GetRecentAppLogs(maxLines int) []string {
+	if maxLines <= 0 {
+		maxLines = 50
+	}
+	if maxLines > 500 {
+		maxLines = 500
+	}
+	return applog.Snapshot(maxLines)
+}

--- a/v2/internal/applog/ring.go
+++ b/v2/internal/applog/ring.go
@@ -1,0 +1,125 @@
+// Package applog holds a bounded in-memory capture of process log output for the UI.
+// Author: Subash Karki
+package applog
+
+import (
+	"bytes"
+	"sync"
+)
+
+var (
+	mu     sync.RWMutex
+	global *Ring
+)
+
+// Init allocates the global ring (call once from main before other logging).
+func Init(maxLines int) {
+	if maxLines < 100 {
+		maxLines = 100
+	}
+	if maxLines > 50_000 {
+		maxLines = 50_000
+	}
+	mu.Lock()
+	global = NewRing(maxLines)
+	mu.Unlock()
+}
+
+// Writer returns the global ring as an io.Writer, or io.Discard if Init was not called.
+func Writer() syncWriter {
+	mu.RLock()
+	r := global
+	mu.RUnlock()
+	if r == nil {
+		return nilRing{}
+	}
+	return r
+}
+
+type nilRing struct{}
+
+func (nilRing) Write(p []byte) (int, error) { return len(p), nil }
+
+type syncWriter interface {
+	Write(p []byte) (n int, err error)
+}
+
+// Ring is a line-oriented ring buffer safe for concurrent Write and Snapshot.
+type Ring struct {
+	mu       sync.Mutex
+	lines    []string
+	capacity int
+	partial  []byte
+}
+
+func NewRing(capacity int) *Ring {
+	ic := capacity
+	if ic > 1024 {
+		ic = 1024
+	}
+	return &Ring{lines: make([]string, 0, ic), capacity: capacity}
+}
+
+// Write implements io.Writer. Incomplete lines are buffered until a newline.
+func (r *Ring) Write(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	buf := append(append([]byte{}, r.partial...), p...)
+	r.partial = r.partial[:0]
+	for len(buf) > 0 {
+		idx := bytes.IndexByte(buf, '\n')
+		if idx < 0 {
+			r.partial = append(r.partial[:0], buf...)
+			break
+		}
+		r.push(string(buf[:idx]))
+		buf = buf[idx+1:]
+	}
+	return len(p), nil
+}
+
+func (r *Ring) push(line string) {
+	if len(r.lines) >= r.capacity {
+		copy(r.lines, r.lines[1:])
+		r.lines = r.lines[:len(r.lines)-1]
+	}
+	r.lines = append(r.lines, line)
+}
+
+// Snapshot returns up to last maxLines entries (oldest first).
+func Snapshot(maxLines int) []string {
+	mu.RLock()
+	r := global
+	mu.RUnlock()
+	if r == nil {
+		return nil
+	}
+	return r.snapshot(maxLines)
+}
+
+func (r *Ring) snapshot(maxLines int) []string {
+	if maxLines <= 0 {
+		maxLines = 500
+	}
+	if maxLines > 10_000 {
+		maxLines = 10_000
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	n := len(r.lines)
+	if n == 0 {
+		return nil
+	}
+	if n <= maxLines {
+		out := make([]string, n)
+		copy(out, r.lines)
+		return out
+	}
+	start := n - maxLines
+	out := make([]string, maxLines)
+	copy(out, r.lines[start:])
+	return out
+}

--- a/v2/main.go
+++ b/v2/main.go
@@ -6,12 +6,15 @@ import (
 	"context"
 	"embed"
 	"errors"
-	"log"
-
+	"io"
+	stdlog "log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sync"
 
+	charmlog "github.com/charmbracelet/log"
+	"github.com/subashkarki/phantom-os-v2/internal/applog"
 	"github.com/subashkarki/phantom-os-v2/internal/app"
 	"github.com/subashkarki/phantom-os-v2/internal/collector"
 	"github.com/subashkarki/phantom-os-v2/internal/composer"
@@ -44,14 +47,20 @@ func main() {
 		}
 	}
 
+	applog.Init(500)
+	mw := io.MultiWriter(os.Stderr, applog.Writer())
+	stdlog.SetOutput(mw)
+	charmlog.SetOutput(mw)
+	slog.SetDefault(slog.New(slog.NewTextHandler(mw, &slog.HandlerOptions{Level: slog.LevelInfo})))
+
 	// 1. Open SQLite database (runs migrations automatically).
 	dbPath, err := db.DefaultDBPath()
 	if err != nil {
-		log.Fatalf("phantomos: resolve db path: %v", err)
+		stdlog.Fatalf("phantomos: resolve db path: %v", err)
 	}
 	database, err := db.Open(dbPath)
 	if err != nil {
-		log.Fatalf("phantomos: open database: %v", err)
+		stdlog.Fatalf("phantomos: open database: %v", err)
 	}
 
 	// 2. Build sqlc Queries backed by the writer connection.
@@ -64,11 +73,11 @@ func main() {
 	journalSvc := journal.NewService("")
 
 	if backfillJournal {
-		log.Printf("phantomos: backfilling journal from DB...")
+		stdlog.Printf("phantomos: backfilling journal from DB...")
 		if err := collector.BackfillJournal(context.Background(), queries, database.Writer, journalSvc); err != nil {
-			log.Fatalf("phantomos: backfill: %v", err)
+			stdlog.Fatalf("phantomos: backfill: %v", err)
 		}
-		log.Printf("phantomos: backfill complete; exiting.")
+		stdlog.Printf("phantomos: backfill complete; exiting.")
 		os.Exit(0)
 	}
 
@@ -87,7 +96,7 @@ func main() {
 	// 6. Set up provider registry with 3-tier config loading.
 	//    Ensure user config directories exist for overrides and custom providers.
 	if err := provider.EnsureConfigDir(); err != nil {
-		log.Printf("phantomos: warning: config dir setup: %v", err)
+		stdlog.Printf("phantomos: warning: config dir setup: %v", err)
 	}
 
 	provRegistry := provider.NewRegistry()
@@ -102,7 +111,7 @@ func main() {
 
 	// LoadAll: embedded (fatal) -> user overrides (warn+skip) -> custom (warn+skip).
 	if err := provRegistry.LoadAll(); err != nil {
-		log.Fatalf("phantomos: provider registry: %v", err)
+		stdlog.Fatalf("phantomos: provider registry: %v", err)
 	}
 
 	// Instantiate all providers using registered adapter factories.
@@ -112,7 +121,7 @@ func main() {
 	// the first enabled provider. Fatal if no providers are available.
 	activeProv, err := selectActiveProvider(provRegistry, queries)
 	if err != nil {
-		log.Fatalf("phantomos: %v", err)
+		stdlog.Fatalf("phantomos: %v", err)
 	}
 
 	// Inject provider into app for bindings_stream and boot_scan.
@@ -125,7 +134,7 @@ func main() {
 	}
 	gamSvc := gamification.NewService(database.Writer, database.Reader, gamEmitFn)
 	if err := gamSvc.Init(context.Background()); err != nil {
-		log.Printf("phantomos: gamification init warning: %v", err)
+		stdlog.Printf("phantomos: gamification init warning: %v", err)
 	}
 	a.SetGamification(gamSvc)
 
@@ -136,7 +145,7 @@ func main() {
 	registry := collector.NewRegistry()
 
 	onTaskComplete := func(sessionID, taskID string) {
-		log.Printf("phantomos: task completed session=%s task=%s", sessionID, taskID)
+		stdlog.Printf("phantomos: task completed session=%s task=%s", sessionID, taskID)
 		gamSvc.OnTaskComplete(context.Background(), sessionID, taskID)
 	}
 
@@ -196,9 +205,9 @@ func main() {
 			tailedMu.Unlock()
 			return
 		}
-		log.Printf("phantomos: auto-tailing session %s", sessionID)
+		stdlog.Printf("phantomos: auto-tailing session %s", sessionID)
 		if err := streamSvc.StartTailing(a.Ctx(), sessionID, jsonlPath); err != nil {
-			log.Printf("phantomos: auto-tail %s: %v", sessionID, err)
+			stdlog.Printf("phantomos: auto-tail %s: %v", sessionID, err)
 		}
 	})
 
@@ -213,7 +222,7 @@ func main() {
 	safety.InstallDefaults(wardsDir)
 	safetySvc, err := safety.NewService(wardsDir, database.Writer, emitFn)
 	if err != nil {
-		log.Printf("phantomos: safety service warning: %v", err)
+		stdlog.Printf("phantomos: safety service warning: %v", err)
 	} else {
 		safetySvc.SetJournal(journalSvc)
 		a.SetSafety(safetySvc)
@@ -251,7 +260,7 @@ func main() {
 		},
 	})
 	if err != nil {
-		log.Fatalf("phantomos: wails run: %v", err)
+		stdlog.Fatalf("phantomos: wails run: %v", err)
 	}
 }
 
@@ -268,7 +277,7 @@ func selectActiveProvider(reg *provider.Registry, queries *db.Queries) (provider
 		if p, ok := reg.Get(pref); ok {
 			return p, nil
 		}
-		log.Printf("phantomos: default_provider=%q not registered; falling back", pref)
+		stdlog.Printf("phantomos: default_provider=%q not registered; falling back", pref)
 	}
 
 	// 2. Legacy default — preserves prior "prefer Claude" behaviour when no preference is set.


### PR DESCRIPTION
## Summary
- Capture process log output (stdlib `log`, `charmbracelet/log`, `slog`) in a bounded in-memory ring (`v2/internal/applog`) and tee to stderr from `v2/main.go`.
- Expose `GetRecentAppLogs` via Wails (`v2/internal/app/bindings_applog.go`) for the renderer (default/cap: 50 lines in UI, up to 500 from Go).
- Add a **Server log** entry in the header (replaces the terminal shortcut): right-side drawer using `PhantomDrawer`, live tail in `AppBackendLogDrawer`.
- **Pin** uses Kobalte `modal={false}`, `preventScroll={false}` when pinned, no overlay in modal mode, and `preventDefault` on outside pointer/focus/interact so the drawer stays open while using the app ([Dialog API](https://kobalte.dev/docs/core/components/dialog/#api-reference)).
- Tour step updated for the new control; `PhantomDrawer` remains backward compatible for Ward Manager (modal-only).

## Test plan
- [ ] `go build` from `v2/`
- [ ] Open app → header Server log icon → drawer shows recent lines and refreshes.
- [ ] Pin → click main workspace → drawer stays open; scroll works; unpin restores overlay behavior.
- [ ] Close drawer → pin resets.


Made with [Cursor](https://cursor.com)