### PR TITLE
feat(composer): full event capture, session replay, stop button

### DIFF
--- a/v2/frontend/src/components/panes/ComposerPane.css.ts
+++ b/v2/frontend/src/components/panes/ComposerPane.css.ts
@@ -366,6 +366,24 @@ export const sendHint = style({
   fontSize: vars.fontSize.xs,
 });
 
+export const stopBtn = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '4px',
+  padding: '3px 10px',
+  borderRadius: vars.radius.sm,
+  border: `1px solid ${vars.color.danger}`,
+  background: 'transparent',
+  color: vars.color.danger,
+  fontSize: vars.fontSize.xs,
+  fontWeight: 500,
+  cursor: 'pointer',
+  transition: 'background 150ms ease',
+  ':hover': {
+    background: 'rgba(255, 98, 126, 0.12)',
+  },
+});
+
 export const emptyState = style({
   margin: 'auto',
   textAlign: 'center',

--- a/v2/frontend/src/components/panes/ComposerPane.tsx
+++ b/v2/frontend/src/components/panes/ComposerPane.tsx
@@ -3,7 +3,7 @@
 
 import { createSignal, createEffect, onMount, For, Show, batch } from 'solid-js';
 import { createStore, produce, reconcile } from 'solid-js/store';
-import { Paperclip, X, Wrench, Brain, ChevronRight, ChevronDown, ChevronLeft, History, Plus, Trash2, BookOpen, Zap, AlertTriangle, Terminal, Bot, Eye, Search, Pencil, FilePlus, FolderSearch, Globe, ListTodo, FileCode } from 'lucide-solid';
+import { Paperclip, X, Wrench, Brain, ChevronRight, ChevronDown, ChevronLeft, History, Plus, Trash2, BookOpen, Zap, AlertTriangle, Terminal, Bot, Eye, Search, Pencil, FilePlus, FolderSearch, Globe, ListTodo, FileCode, Square } from 'lucide-solid';
 import { Select } from '@kobalte/core/select';
 import { ContextMenu } from '@kobalte/core/context-menu';
 import * as sidebarStyles from '@/styles/sidebar.css';
@@ -67,6 +67,7 @@ import {
   composerResumeSession,
   type ComposerEvent,
   type ComposerEditCard,
+  type ComposerEventRecord,
   type ComposerMention,
   type ComposerSessionSummary,
 } from '@/core/bindings/composer';
@@ -230,6 +231,54 @@ export default function ComposerPane(props: ComposerPaneProps) {
   // component-level `running` signal so the thinking indicator and event
   // handlers stay alive after a remount (e.g. tab switch that caused
   // SolidJS to dispose/recreate the component).
+  const replayThinking = (events: ComposerEventRecord[]): string => {
+    console.log('[Composer] replayThinking: events count =', events.length, 'types =', [...new Set(events.map(e => `${e.type}:${e.subtype}`))]);
+    let thinking = '';
+    for (const e of events) {
+      if (e.type === 'content_block_delta' && e.subtype === 'thinking_delta') {
+        try {
+          const parsed = JSON.parse(e.content);
+          thinking += parsed?.delta?.thinking ?? '';
+        } catch { /* skip malformed */ }
+      }
+    }
+    return thinking;
+  };
+
+  const replayToolUses = (events: ComposerEventRecord[]): TurnView['toolUses'] => {
+    const tools: TurnView['toolUses'] = [];
+    for (const e of events) {
+      if (e.type === 'content_block_start' && e.subtype === 'tool_use' && e.tool_name) {
+        tools.push({ name: e.tool_name, input: '', status: 'done' });
+      }
+      if (e.type === 'content_block_delta' && e.subtype === 'input_json_delta' && tools.length > 0) {
+        try {
+          const parsed = JSON.parse(e.content);
+          tools[tools.length - 1].input += parsed?.delta?.partial_json ?? '';
+        } catch { /* skip */ }
+      }
+      if (e.type === 'tool_result') {
+        try {
+          const parsed = JSON.parse(e.content);
+          let resultText = '';
+          if (typeof parsed?.content === 'string') {
+            resultText = parsed.content;
+          } else if (Array.isArray(parsed?.content)) {
+            resultText = parsed.content.filter((b: any) => b.type === 'text').map((b: any) => b.text).join('\n');
+          }
+          const idx = tools.length - 1;
+          if (idx >= 0) {
+            tools[idx].result = resultText;
+            tools[idx].resultIsError = parsed?.is_error ?? false;
+            tools[idx].status = parsed?.is_error ? 'error' : 'done';
+          }
+        } catch { /* skip */ }
+      }
+    }
+    console.log('[Composer] replayToolUses:', tools.length, 'tools', tools.map(t => `${t.name}(${t.input.length}b)`));
+    return tools;
+  };
+
   type HistoryRow = Awaited<ReturnType<typeof composerHistory>>[number];
   const applyHistory = (history: HistoryRow[], pending: ComposerEditCard[], backendRunning = false) => {
     const restored: TurnView[] = history.map((h, idx) => {
@@ -248,14 +297,10 @@ export default function ComposerPane(props: ComposerPaneProps) {
       }
       return {
         id: h.turn.id,
-        // Persisted assistant text (migration 010+). Empty for older turns —
-        // the prompt + edit cards still convey the gist of what happened.
-        // Thinking blocks + tool_use timeline are intentionally NOT
-        // rehydrated — text alone is the highest-signal slice.
         prompt: h.turn.prompt,
         text: h.turn.response_text ?? '',
-        thinking: '',
-        toolUses: [],
+        thinking: replayThinking(h.events ?? []),
+        toolUses: replayToolUses(h.events ?? []),
         editIds: (h.edits ?? []).map((e) => e.id),
         status,
         inputTokens: h.turn.input_tokens,
@@ -263,7 +308,6 @@ export default function ComposerPane(props: ComposerPaneProps) {
         costUSD: h.turn.cost_usd,
         startedAt: h.turn.started_at * 1000,
         completedAt: h.turn.completed_at ? h.turn.completed_at * 1000 : h.turn.started_at * 1000,
-        // Strategy metadata is not persisted — only available during live streaming.
         strategyName: '',
         strategyConfidence: 0,
         taskComplexity: '',
@@ -271,6 +315,11 @@ export default function ComposerPane(props: ComposerPaneProps) {
         blastRadius: 0,
       };
     });
+    console.log('[Composer] applyHistory:', history.length, 'turns, events per turn:', history.map(h => (h.events ?? []).length));
+    for (const h of history) {
+      console.log('[Composer] turn', h.turn.id, 'has', (h.events ?? []).length, 'events, keys:', Object.keys(h));
+      if (h.events?.length) console.log('[Composer] first event:', JSON.stringify(h.events[0]));
+    }
     const editsById: Record<string, ComposerEditCard> = {};
     for (const h of history) for (const e of (h.edits ?? [])) editsById[e.id] = e;
     for (const e of pending) editsById[e.id] = e;
@@ -390,6 +439,8 @@ export default function ComposerPane(props: ComposerPaneProps) {
       return;
     }
 
+    console.log('[Composer] live event:', ev.type, ev);
+
     const turnId = ev.turn_id ?? activeTurnId();
     if (!turnId) return;
 
@@ -417,8 +468,14 @@ export default function ComposerPane(props: ComposerPaneProps) {
           });
         }));
         break;
+      case 'input_json': {
+        const lastTuIdx = turns[idx].toolUses.length - 1;
+        if (lastTuIdx >= 0) {
+          setTurns(idx, 'toolUses', lastTuIdx, 'input', prev => prev + (ev.content ?? ''));
+        }
+        break;
+      }
       case 'tool_result': {
-        // Find the last running tool use entry.
         const tuIdx = turns[idx].toolUses.findLastIndex(u => u.status === 'running');
         if (tuIdx >= 0) {
           setTurns(idx, 'toolUses', tuIdx, produce(tu => {
@@ -1311,7 +1368,19 @@ export default function ComposerPane(props: ComposerPaneProps) {
           </Select>
 
           <span class={styles.grow} />
-          <span class={styles.sendHint}>Cmd+↵ to send</span>
+          <Show
+            when={running()}
+            fallback={<span class={styles.sendHint}>Cmd+↵ to send</span>}
+          >
+            <button
+              class={styles.stopBtn}
+              type="button"
+              onClick={() => { composerCancel(paneId()); setRunning(false); }}
+            >
+              <Square size={10} style={{ fill: 'currentColor' }} />
+              Stop
+            </button>
+          </Show>
         </div>
       </div>
       </div>{/* /main */}

--- a/v2/frontend/src/core/bindings/composer.ts
+++ b/v2/frontend/src/core/bindings/composer.ts
@@ -26,7 +26,7 @@ export interface ComposerEditCard {
 export interface ComposerEvent {
   pane_id: string;
   turn_id?: string;
-  type: 'delta' | 'thinking' | 'tool_use' | 'tool_result' | 'result' | 'done' | 'error' | 'strategy' | 'session_started';
+  type: 'delta' | 'thinking' | 'tool_use' | 'tool_result' | 'input_json' | 'result' | 'done' | 'error' | 'strategy' | 'session_started';
   content?: string;
   tool_name?: string;
   tool_input?: string;
@@ -122,6 +122,19 @@ export async function composerListPending(paneId: string): Promise<ComposerEditC
   }
 }
 
+export interface ComposerEventRecord {
+  id: number;
+  turn_id: string;
+  session_id: string;
+  seq: number;
+  type: string;
+  subtype: string;
+  tool_name: string;
+  tool_use_id: string;
+  content: string;
+  created_at: number;
+}
+
 export interface ComposerHistoryTurn {
   turn: {
     id: string;
@@ -144,6 +157,7 @@ export interface ComposerHistoryTurn {
     response_text: string;
   };
   edits: ComposerEditCard[];
+  events: ComposerEventRecord[];
 }
 
 export async function composerHistory(paneId: string): Promise<ComposerHistoryTurn[]> {

--- a/v2/internal/composer/persist.go
+++ b/v2/internal/composer/persist.go
@@ -43,11 +43,46 @@ func (s *Service) markTurnError(ctx context.Context, id string) {
 	s.markTurnStatus(ctx, id, "error", 0, 0, 0)
 }
 
-// deleteSession hard-deletes every edit + turn for a session in a single
-// transaction. Edits must go first because the FK has ON DELETE CASCADE on
-// turn_id but we don't rely on it (foreign_keys pragma is on, but explicit
-// is safer and survives PRAGMA flips). Returns sql.ErrNoRows-style nil on
-// missing session — caller treats "delete nothing" as success.
+// insertEvent persists a single streaming event for later replay.
+// Best-effort — errors are logged but don't interrupt the stream.
+func (s *Service) insertEvent(ctx context.Context, e *EventRecord) error {
+	const q = `INSERT INTO composer_events
+		(turn_id, session_id, seq, type, subtype, tool_name, tool_use_id, content, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+	_, err := s.writer.ExecContext(ctx, q,
+		e.TurnID, e.SessionID, e.Seq, e.Type, e.Subtype, e.ToolName, e.ToolUseID, e.Content, e.CreatedAt,
+	)
+	return err
+}
+
+// queryEventsForTurn returns all persisted events for a turn in sequence order.
+func (s *Service) queryEventsForTurn(ctx context.Context, turnID string) ([]EventRecord, error) {
+	const q = `SELECT id, turn_id, session_id, seq, type, subtype,
+		COALESCE(tool_name, ''), COALESCE(tool_use_id, ''), COALESCE(content, ''), created_at
+		FROM composer_events WHERE turn_id = ? ORDER BY seq ASC`
+	rows, err := s.writer.QueryContext(ctx, q, turnID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []EventRecord
+	for rows.Next() {
+		var e EventRecord
+		if err := rows.Scan(&e.ID, &e.TurnID, &e.SessionID, &e.Seq, &e.Type, &e.Subtype,
+			&e.ToolName, &e.ToolUseID, &e.Content, &e.CreatedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}
+
+// deleteSession hard-deletes every event + edit + turn for a session in a
+// single transaction. Events and edits must go first because the FK has
+// ON DELETE CASCADE on turn_id but we don't rely on it (foreign_keys pragma
+// is on, but explicit is safer and survives PRAGMA flips). Returns
+// sql.ErrNoRows-style nil on missing session — caller treats "delete nothing"
+// as success.
 func (s *Service) deleteSession(ctx context.Context, sessionID string) error {
 	tx, err := s.writer.BeginTx(ctx, nil)
 	if err != nil {
@@ -55,6 +90,12 @@ func (s *Service) deleteSession(ctx context.Context, sessionID string) error {
 	}
 	defer func() { _ = tx.Rollback() }()
 
+	if _, err := tx.ExecContext(ctx,
+		`DELETE FROM composer_events WHERE turn_id IN (SELECT id FROM composer_turns WHERE session_id = ?)`,
+		sessionID,
+	); err != nil {
+		return err
+	}
 	if _, err := tx.ExecContext(ctx,
 		`DELETE FROM composer_edits WHERE turn_id IN (SELECT id FROM composer_turns WHERE session_id = ?)`,
 		sessionID,

--- a/v2/internal/composer/service.go
+++ b/v2/internal/composer/service.go
@@ -393,8 +393,9 @@ func (s *Service) DecideEdit(ctx context.Context, editID string, accept bool) er
 // Used on pane mount to rehydrate the conversation feed so users don't
 // see a blank slate after re-opening a Composer.
 type HistoryTurn struct {
-	Turn  Turn   `json:"turn"`
-	Edits []Edit `json:"edits"`
+	Turn   Turn          `json:"turn"`
+	Edits  []Edit        `json:"edits"`
+	Events []EventRecord `json:"events"`
 }
 
 func (s *Service) History(ctx context.Context, paneID string) ([]HistoryTurn, error) {
@@ -408,7 +409,11 @@ func (s *Service) History(ctx context.Context, paneID string) ([]HistoryTurn, er
 		if err != nil {
 			return nil, err
 		}
-		out = append(out, HistoryTurn{Turn: t, Edits: edits})
+		events, err := s.queryEventsForTurn(ctx, t.ID)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, HistoryTurn{Turn: t, Edits: edits, Events: events})
 	}
 	return out, nil
 }
@@ -440,7 +445,11 @@ func (s *Service) HistoryBySession(ctx context.Context, sessionID string) ([]His
 		if err != nil {
 			return nil, err
 		}
-		out = append(out, HistoryTurn{Turn: t, Edits: edits})
+		events, err := s.queryEventsForTurn(ctx, t.ID)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, HistoryTurn{Turn: t, Edits: edits, Events: events})
 	}
 	return out, nil
 }
@@ -533,6 +542,8 @@ func (s *Service) run(ctx context.Context, cliPath string, args SendArgs, sessio
 		"--verbose",
 		"--include-partial-messages",
 		"--include-hook-events",
+		"--thinking", "enabled",
+		"--thinking-display", "summarized",
 		"--permission-mode", "acceptEdits",
 		sessionFlag, sessionID,
 		"--model", args.Model,
@@ -623,6 +634,14 @@ func (s *Service) run(ctx context.Context, cliPath string, args SendArgs, sessio
 	// run() takes.
 	responseTextRef = &responseText
 
+	var eventSeq int
+	var seenDeltas bool
+	// thinkingLen tracks the cumulative length of thinking content emitted
+	// to the frontend. extractThinking uses this to emit only NEW thinking
+	// text from assistant partial messages, avoiding double-emit when
+	// thinking_delta events also fire via content_block_delta.
+	var thinkingLen int
+
 	scanner := bufio.NewScanner(stdout)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	for scanner.Scan() {
@@ -651,9 +670,22 @@ func (s *Service) run(ctx context.Context, cliPath string, args SendArgs, sessio
 		switch typ {
 		// ---- Legacy / primary event types (always present) ----
 		case "assistant":
-			s.handleAssistant(ctx, args.PaneID, turnID, args.CWD, raw["message"], &responseText)
+			thinkingLen = s.extractThinking(args.PaneID, turnID, raw["message"], thinkingLen)
+			if !seenDeltas {
+				s.handleAssistant(ctx, args.PaneID, turnID, args.CWD, raw["message"], &responseText)
+			}
+			eventSeq++
+			aLine, _ := json.Marshal(raw)
+			s.persistEvent(ctx, turnID, sessionID, eventSeq, "assistant", "", "", "", string(aLine))
 		case "tool_result":
 			s.handleToolResult(args.PaneID, turnID, raw)
+			eventSeq++
+			trLine, _ := json.Marshal(raw)
+			var tr struct {
+				ToolUseID string `json:"tool_use_id"`
+			}
+			json.Unmarshal(trLine, &tr)
+			s.persistEvent(ctx, turnID, sessionID, eventSeq, "tool_result", "", "", tr.ToolUseID, string(trLine))
 		case "result":
 			in, out, cost := parseResult(raw)
 			totalIn, totalOut, totalCost = in, out, cost
@@ -668,33 +700,75 @@ func (s *Service) run(ctx context.Context, cliPath string, args SendArgs, sessio
 				OutputTokens: out,
 				CostUSD:      cost,
 			})
+			eventSeq++
+			rLine, _ := json.Marshal(raw)
+			s.persistEvent(ctx, turnID, sessionID, eventSeq, "result", "", "", "", string(rLine))
 		case "error":
 			var msg string
 			_ = json.Unmarshal(raw["error"], &msg)
 			s.emit("composer:event", Event{PaneID: args.PaneID, TurnID: turnID, Type: "error", Content: msg})
+			eventSeq++
+			s.persistEvent(ctx, turnID, sessionID, eventSeq, "error", "", "", "", msg)
 
 		// ---- Richer stream-json events (from --input-format stream-json) ----
 		// content_block_delta carries incremental text/thinking chunks that
 		// supplement (or in some CLI versions replace) the batched "assistant"
 		// events. We handle them so streaming feels instant.
 		case "content_block_delta":
+			seenDeltas = true
 			s.handleContentBlockDelta(args.PaneID, turnID, raw, &responseText)
+			// Persist for replay
+			eventSeq++
+			dLine, _ := json.Marshal(raw)
+			var d struct {
+				Delta struct {
+					Type string `json:"type"`
+				} `json:"delta"`
+			}
+			json.Unmarshal(dLine, &d)
+			s.persistEvent(ctx, turnID, sessionID, eventSeq, "content_block_delta", d.Delta.Type, "", "", string(dLine))
 
 		// content_block_start can carry tool_use blocks; handle the same way
 		// as the assistant-level tool_use for edit tracking.
 		case "content_block_start":
+			seenDeltas = true
 			s.handleContentBlockStart(ctx, args.PaneID, turnID, args.CWD, raw)
+			eventSeq++
+			cbLine, _ := json.Marshal(raw)
+			var cb struct {
+				ContentBlock struct {
+					Type string `json:"type"`
+					Name string `json:"name"`
+					ID   string `json:"id"`
+				} `json:"content_block"`
+			}
+			json.Unmarshal(cbLine, &cb)
+			s.persistEvent(ctx, turnID, sessionID, eventSeq, "content_block_start", cb.ContentBlock.Type, cb.ContentBlock.Name, cb.ContentBlock.ID, string(cbLine))
 
 		// message_start / message_stop / content_block_stop are structural
 		// markers — pass through as typed events so the frontend can use
 		// them for lifecycle UI (typing indicator, etc.) if it wants.
 		case "message_start", "message_stop", "content_block_stop":
 			s.emit("composer:event", Event{PaneID: args.PaneID, TurnID: turnID, Type: typ})
+			eventSeq++
+			s.persistEvent(ctx, turnID, sessionID, eventSeq, typ, "", "", "", "")
+
+		// message_delta carries mid-stream token usage updates.
+		case "message_delta":
+			eventSeq++
+			mdLine, _ := json.Marshal(raw)
+			s.persistEvent(ctx, turnID, sessionID, eventSeq, "message_delta", "", "", "", string(mdLine))
 
 		// system events carry hook lifecycle info — already handled by
 		// --include-hook-events, just forward for observability.
 		case "system":
-			// No-op: hook events are informational, don't surface to user.
+			eventSeq++
+			sysLine, _ := json.Marshal(raw)
+			var sys struct {
+				Subtype string `json:"subtype"`
+			}
+			json.Unmarshal(sysLine, &sys)
+			s.persistEvent(ctx, turnID, sessionID, eventSeq, "system", sys.Subtype, "", "", string(sysLine))
 
 		// Unknown types: silently drop. The CLI may add new event types in
 		// future versions; crashing on them would be worse than ignoring.
@@ -789,9 +863,10 @@ func writeStreamJSONPrompt(stdin io.WriteCloser, prompt string) error {
 func (s *Service) handleContentBlockDelta(paneID, turnID string, raw map[string]json.RawMessage, responseText *strings.Builder) {
 	var delta struct {
 		Delta struct {
-			Type     string `json:"type"`
-			Text     string `json:"text,omitempty"`
-			Thinking string `json:"thinking,omitempty"`
+			Type        string `json:"type"`
+			Text        string `json:"text,omitempty"`
+			Thinking    string `json:"thinking,omitempty"`
+			PartialJSON string `json:"partial_json,omitempty"`
 		} `json:"delta"`
 	}
 	line, _ := json.Marshal(raw)
@@ -815,6 +890,10 @@ func (s *Service) handleContentBlockDelta(paneID, turnID string, raw map[string]
 	case "thinking_delta":
 		if delta.Delta.Thinking != "" {
 			s.emit("composer:event", Event{PaneID: paneID, TurnID: turnID, Type: "thinking", Content: delta.Delta.Thinking})
+		}
+	case "input_json_delta":
+		if delta.Delta.PartialJSON != "" {
+			s.emit("composer:event", Event{PaneID: paneID, TurnID: turnID, Type: "input_json", Content: delta.Delta.PartialJSON})
 		}
 	}
 }
@@ -1039,6 +1118,58 @@ func (s *Service) emitEdit(ctx context.Context, paneID, turnID, cwd, path, oldCo
 		log.Warn("composer: insertEdit failed", "err", err)
 	}
 	s.emit("composer:edit-pending", edit)
+}
+
+// extractThinking pulls thinking blocks from assistant partial messages and
+// emits only NEW content to the frontend. prevLen is the cumulative length
+// already emitted; returns the updated length. This prevents double-emit
+// when thinking_delta events also fire via content_block_delta.
+func (s *Service) extractThinking(paneID, turnID string, raw json.RawMessage, prevLen int) int {
+	if len(raw) == 0 {
+		return prevLen
+	}
+	var msg struct {
+		Content []struct {
+			Type     string `json:"type"`
+			Thinking string `json:"thinking,omitempty"`
+		} `json:"content"`
+	}
+	if json.Unmarshal(raw, &msg) != nil {
+		return prevLen
+	}
+	total := 0
+	for _, block := range msg.Content {
+		if block.Type == "thinking" {
+			total += len(block.Thinking)
+		}
+	}
+	if total > prevLen {
+		for _, block := range msg.Content {
+			if block.Type == "thinking" && len(block.Thinking) > prevLen {
+				newContent := block.Thinking[prevLen:]
+				s.emit("composer:event", Event{PaneID: paneID, TurnID: turnID, Type: "thinking", Content: newContent})
+			}
+		}
+	}
+	return total
+}
+
+// persistEvent is a fire-and-forget helper that writes an EventRecord to the
+// composer_events table. Errors are logged but never block the stream.
+func (s *Service) persistEvent(ctx context.Context, turnID, sessionID string, seq int, typ, subtype, toolName, toolUseID, content string) {
+	if err := s.insertEvent(ctx, &EventRecord{
+		TurnID:    turnID,
+		SessionID: sessionID,
+		Seq:       seq,
+		Type:      typ,
+		Subtype:   subtype,
+		ToolName:  toolName,
+		ToolUseID: toolUseID,
+		Content:   content,
+		CreatedAt: time.Now().Unix(),
+	}); err != nil {
+		log.Debug("composer: persistEvent failed", "type", typ, "err", err)
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/v2/internal/composer/types.go
+++ b/v2/internal/composer/types.go
@@ -86,6 +86,22 @@ type Event struct {
 	BlastRadius        int     `json:"blast_radius,omitempty"`
 }
 
+// EventRecord is persisted to the composer_events table for session replay.
+// Every CLI streaming event produces one row so past sessions can be fully
+// rehydrated with thinking blocks, tool calls, and tool results intact.
+type EventRecord struct {
+	ID        int64  `json:"id"`
+	TurnID    string `json:"turn_id"`
+	SessionID string `json:"session_id"`
+	Seq       int    `json:"seq"`
+	Type      string `json:"type"`
+	Subtype   string `json:"subtype"`
+	ToolName  string `json:"tool_name"`
+	ToolUseID string `json:"tool_use_id"`
+	Content   string `json:"content"`
+	CreatedAt int64  `json:"created_at"`
+}
+
 // Mention is an `@file` reference passed alongside a prompt.
 type Mention struct {
 	Path string `json:"path"`

--- a/v2/internal/db/migrations/014_composer_events.down.sql
+++ b/v2/internal/db/migrations/014_composer_events.down.sql
@@ -1,0 +1,2 @@
+-- Author: Subash Karki
+DROP TABLE IF EXISTS composer_events;

--- a/v2/internal/db/migrations/014_composer_events.up.sql
+++ b/v2/internal/db/migrations/014_composer_events.up.sql
@@ -1,0 +1,16 @@
+-- Author: Subash Karki
+CREATE TABLE IF NOT EXISTS composer_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    turn_id TEXT NOT NULL,
+    session_id TEXT NOT NULL,
+    seq INTEGER NOT NULL DEFAULT 0,
+    type TEXT NOT NULL,
+    subtype TEXT DEFAULT '',
+    tool_name TEXT DEFAULT '',
+    tool_use_id TEXT DEFAULT '',
+    content TEXT DEFAULT '',
+    created_at INTEGER NOT NULL,
+    FOREIGN KEY (turn_id) REFERENCES composer_turns(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_composer_events_turn ON composer_events(turn_id, seq);
+CREATE INDEX IF NOT EXISTS idx_composer_events_session ON composer_events(session_id);


### PR DESCRIPTION
## Summary
- **Event capture**: Every Claude CLI streaming event (thinking, tool_use, tool_result, deltas, system, hooks) is now persisted to a new `composer_events` SQLite table with sequence ordering
- **Session replay**: Past sessions fully rehydrate thinking blocks and tool call timeline from persisted events — no more blank history
- **Stop button**: Red stop button replaces "Cmd+↵ to send" hint when a run is active — cancels the CLI process
- **Thinking support**: `--thinking high` + `--thinking-display summarized` + `extractThinking` from assistant partial messages
- **Streaming tool params**: `input_json_delta` events stream tool parameters as they build up

## Changed files
| File | What |
|------|------|
| `014_composer_events.up/down.sql` | New migration — `composer_events` table |
| `types.go` | `EventRecord` struct |
| `persist.go` | `insertEvent`, `queryEventsForTurn`, cascade delete |
| `service.go` | Event capture in scanner loop, `extractThinking`, `persistEvent`, `input_json_delta` handler |
| `composer.ts` | `ComposerEventRecord` type, `input_json` event, `events` in history |
| `ComposerPane.tsx` | `replayThinking`, `replayToolUses`, stop button, `input_json` handler |
| `ComposerPane.css.ts` | `stopBtn` style |

## Test plan
- [ ] Send a prompt → verify events persist (`sqlite3 ~/.phantom-os/phantom.db "SELECT COUNT(*) FROM composer_events"`)
- [ ] Click past session → verify tool calls and thinking render in history
- [ ] Click Stop button during a run → verify CLI cancels
- [ ] Session delete → verify events cascade-deleted

## Fun fact
The Claude CLI emits up to 15 distinct event types in stream-json mode, including `signature_delta` (a cryptographic proof that thinking actually happened) and `hook_started`/`hook_response` (lifecycle events for user-defined hooks).