### PR TITLE
feat(composer): slash commands, diff fix, auto-accept

### DIFF
--- a/v2/frontend/src/components/panes/ComposerDiffCard.tsx
+++ b/v2/frontend/src/components/panes/ComposerDiffCard.tsx
@@ -78,7 +78,7 @@ const ComposerDiffCard = (props: ComposerDiffCardProps) => {
   // Signals
   const [monaco, setMonaco] = createSignal<typeof MonacoNS | null>(null);
   const [isReady, setIsReady] = createSignal(false);
-  const [expanded, setExpanded] = createSignal(true);
+  const [expanded, setExpanded] = createSignal(false);
   const [sideBySide, setSideBySide] = createSignal(false); // inline by default for chat
 
   // Derived

--- a/v2/frontend/src/components/panes/ComposerPane.css.ts
+++ b/v2/frontend/src/components/panes/ComposerPane.css.ts
@@ -74,7 +74,7 @@ export const feed = style({
 });
 
 export const userTurn = style({
-  fontSize: vars.fontSize.sm,
+  fontSize: 'inherit',
   color: vars.color.textPrimary,
   selectors: {
     '&::before': {
@@ -93,7 +93,7 @@ export const userTurn = style({
 });
 
 export const assistantText = style({
-  fontSize: vars.fontSize.sm,
+  fontSize: 'inherit',
   color: vars.color.textPrimary,
   wordBreak: 'break-word',
   lineHeight: 1.6,
@@ -219,7 +219,8 @@ export const thinkingBlock = style({
 
 export const composerArea = style({
   borderTop: `1px solid ${vars.color.divider}`,
-  padding: `${vars.space.md} ${vars.space.xxl} ${vars.space.lg}`,
+  padding: `${vars.space.lg} ${vars.space.xxl} ${vars.space.xl}`,
+  marginTop: vars.space.sm,
   background: vars.color.bgSecondary,
   display: 'flex',
   flexDirection: 'column',
@@ -274,9 +275,10 @@ export const textarea = style({
 export const composerToolbar = style({
   display: 'flex',
   alignItems: 'center',
-  gap: vars.space.sm,
+  gap: vars.space.md,
   fontSize: vars.fontSize.xs,
   color: vars.color.textSecondary,
+  paddingTop: vars.space.xs,
 });
 
 export const grow = style({ flex: 1 });
@@ -382,6 +384,69 @@ export const stopBtn = style({
   ':hover': {
     background: 'rgba(255, 98, 126, 0.12)',
   },
+});
+
+export const fontSizeSelect = style({
+  background: vars.color.bgPrimary,
+  border: `1px solid ${vars.color.border}`,
+  color: vars.color.textSecondary,
+  borderRadius: vars.radius.sm,
+  padding: '2px 4px',
+  fontSize: '11px',
+  fontFamily: vars.font.mono,
+  cursor: 'pointer',
+  outline: 'none',
+  ':focus': {
+    borderColor: vars.color.borderFocus,
+  },
+});
+
+export const jumpToLatest = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: vars.space.xs,
+  width: '100%',
+  padding: `${vars.space.xs} 0`,
+  background: `color-mix(in srgb, ${vars.color.accent} 10%, ${vars.color.bgSecondary})`,
+  border: 'none',
+  borderTop: `1px solid ${vars.color.divider}`,
+  color: vars.color.accent,
+  fontSize: vars.fontSize.xs,
+  fontWeight: 500,
+  cursor: 'pointer',
+  flexShrink: 0,
+  ':hover': {
+    background: `color-mix(in srgb, ${vars.color.accent} 18%, ${vars.color.bgSecondary})`,
+  },
+});
+
+export const progressStrip = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: vars.space.sm,
+  padding: `${vars.space.xs} ${vars.space.xxl}`,
+  borderTop: `1px solid ${vars.color.divider}`,
+  background: `color-mix(in srgb, ${vars.color.accent} 5%, ${vars.color.bgSecondary})`,
+  fontSize: vars.fontSize.xs,
+  color: vars.color.textSecondary,
+  flexShrink: 0,
+});
+
+export const progressDot = style({
+  width: 6,
+  height: 6,
+  borderRadius: '50%',
+  background: vars.color.accent,
+  animation: `${pendingDotPulse} 1.2s ease-in-out infinite`,
+  flexShrink: 0,
+});
+
+export const progressLabel = style({
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  fontFamily: vars.font.mono,
 });
 
 export const emptyState = style({

--- a/v2/frontend/src/components/panes/ComposerPane.css.ts
+++ b/v2/frontend/src/components/panes/ComposerPane.css.ts
@@ -426,6 +426,61 @@ export const composerAreaDragOver = style({
   outlineOffset: -2,
 });
 
+// ── Slash command palette ────────────────────────────────────────────
+export const commandPalette = style({
+  position: 'relative',
+  maxHeight: '240px',
+  overflowY: 'auto',
+  background: vars.color.bgPrimary,
+  border: `1px solid ${vars.color.border}`,
+  borderRadius: vars.radius.md,
+  padding: vars.space.xs,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1px',
+});
+
+export const commandItem = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: vars.space.sm,
+  padding: `${vars.space.xs} ${vars.space.sm}`,
+  borderRadius: vars.radius.sm,
+  cursor: 'pointer',
+  fontSize: vars.fontSize.xs,
+  ':hover': {
+    background: vars.color.bgHover,
+  },
+});
+
+export const commandItemActive = style({
+  background: vars.color.bgHover,
+});
+
+export const commandName = style({
+  fontFamily: vars.font.mono,
+  fontWeight: 600,
+  color: vars.color.accent,
+  flexShrink: 0,
+});
+
+export const commandDesc = style({
+  color: vars.color.textSecondary,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  flex: 1,
+});
+
+export const commandSource = style({
+  fontSize: '10px',
+  color: vars.color.textDisabled,
+  flexShrink: 0,
+  padding: '1px 4px',
+  borderRadius: vars.radius.sm,
+  background: vars.color.bgTertiary,
+});
+
 // `.copy-btn` is appended via DOM in ComposerMarkdown after each render
 // (DOMPurify strips inline handlers, hence the post-render walk). Styled
 // globally so the button is positioned absolutely inside the <pre> code

--- a/v2/frontend/src/components/panes/ComposerPane.tsx
+++ b/v2/frontend/src/components/panes/ComposerPane.tsx
@@ -437,7 +437,10 @@ export default function ComposerPane(props: ComposerPaneProps) {
     void refreshSessions();
 
     // Load slash commands for autocomplete.
-    composerListCommands(cwd()).then(setCommands);
+    composerListCommands(cwd()).then((cmds) => {
+      console.log('[Composer] loaded commands:', cmds.length, cmds.filter(c => c.name.startsWith('team')).map(c => c.name));
+      setCommands(cmds);
+    });
 
     // If this pane was opened with a sessionId from the sidebar, bind it
     // BEFORE the rehydration query so the next Send resumes correctly,

--- a/v2/frontend/src/components/panes/ComposerPane.tsx
+++ b/v2/frontend/src/components/panes/ComposerPane.tsx
@@ -65,6 +65,8 @@ import {
   composerListSessions,
   composerHistoryBySession,
   composerResumeSession,
+  composerListCommands,
+  type ComposerCommand,
   type ComposerEvent,
   type ComposerEditCard,
   type ComposerEventRecord,
@@ -186,10 +188,25 @@ export default function ComposerPane(props: ComposerPaneProps) {
   // per-user default so power users who always want clean answers don't
   // have to flip it every time.
   const [noContext, setNoContext] = createSignal(false);
-  const [autoAccept, setAutoAccept] = createSignal(false);
+  const [autoAccept, setAutoAccept] = createSignal(true);
   const [dragOver, setDragOver] = createSignal(false);
   const [showMemory, setShowMemory] = createSignal(false);
   const [showSkills, setShowSkills] = createSignal(false);
+
+  // Slash command autocomplete
+  const [commands, setCommands] = createSignal<ComposerCommand[]>([]);
+  const [showCommandPalette, setShowCommandPalette] = createSignal(false);
+  const [commandFilter, setCommandFilter] = createSignal('');
+  const [commandIdx, setCommandIdx] = createSignal(0);
+
+  const filteredCommands = () => {
+    const filter = commandFilter().toLowerCase();
+    if (!filter) return commands();
+    return commands().filter(c =>
+      c.name.toLowerCase().includes(filter) ||
+      c.description.toLowerCase().includes(filter)
+    );
+  };
 
   // Past Sessions sidebar — list, collapsed-state, and the currently
   // active claude session_id. activeSessionId tracks the live session this
@@ -388,11 +405,14 @@ export default function ComposerPane(props: ComposerPaneProps) {
 
     // Auto-accept edits toggle — when on, edit cards are accepted as they arrive.
     void loadPref('composer_auto_accept_edits').then((val) => {
-      if (val === 'true') setAutoAccept(true);
+      if (val === 'false') setAutoAccept(false);
     });
 
     // Kick off the sessions list in parallel — doesn't block history load.
     void refreshSessions();
+
+    // Load slash commands for autocomplete.
+    composerListCommands(cwd()).then(setCommands);
 
     // If this pane was opened with a sessionId from the sidebar, bind it
     // BEFORE the rehydration query so the next Send resumes correctly,
@@ -761,6 +781,33 @@ export default function ComposerPane(props: ComposerPaneProps) {
   };
 
   const handleKeyDown = (e: KeyboardEvent) => {
+    // Slash command palette navigation
+    if (showCommandPalette()) {
+      const cmds = filteredCommands();
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setCommandIdx(i => Math.min(i + 1, cmds.length - 1));
+        return;
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setCommandIdx(i => Math.max(i - 1, 0));
+        return;
+      }
+      if (e.key === 'Enter' && !e.metaKey && !e.ctrlKey && cmds.length > 0) {
+        e.preventDefault();
+        const selected = cmds[commandIdx()];
+        setInput('/' + selected.name + ' ');
+        setShowCommandPalette(false);
+        textareaRef?.focus();
+        return;
+      }
+      if (e.key === 'Escape') {
+        setShowCommandPalette(false);
+        return;
+      }
+    }
+
     if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
       e.preventDefault();
       handleSend();
@@ -1268,12 +1315,47 @@ export default function ComposerPane(props: ComposerPaneProps) {
           </div>
         </Show>
 
+        <Show when={showCommandPalette() && filteredCommands().length > 0}>
+          <div class={styles.commandPalette}>
+            <For each={filteredCommands()}>
+              {(cmd, i) => (
+                <div
+                  class={`${styles.commandItem} ${i() === commandIdx() ? styles.commandItemActive : ''}`}
+                  onClick={() => {
+                    setInput('/' + cmd.name + ' ');
+                    setShowCommandPalette(false);
+                    textareaRef?.focus();
+                  }}
+                >
+                  <span class={styles.commandName}>/{cmd.name}</span>
+                  <Show when={cmd.description}>
+                    <span class={styles.commandDesc}>{cmd.description}</span>
+                  </Show>
+                  <span class={styles.commandSource}>{cmd.source}</span>
+                </div>
+              )}
+            </For>
+          </div>
+        </Show>
+
         <textarea
           ref={textareaRef}
           class={styles.textarea}
           placeholder="What should Composer do… (paste an image to attach it)"
           value={input()}
-          onInput={(e) => setInput(e.currentTarget.value)}
+          onInput={(e) => {
+            const val = e.currentTarget.value;
+            setInput(val);
+            // Detect slash command prefix
+            if (val.startsWith('/') && !val.includes('\n')) {
+              const filter = val.slice(1).split(' ')[0];
+              setCommandFilter(filter);
+              setShowCommandPalette(true);
+              setCommandIdx(0);
+            } else {
+              setShowCommandPalette(false);
+            }
+          }}
           onKeyDown={handleKeyDown}
           onPaste={handleTextareaPaste}
           rows={3}

--- a/v2/frontend/src/components/panes/ComposerPane.tsx
+++ b/v2/frontend/src/components/panes/ComposerPane.tsx
@@ -192,6 +192,11 @@ export default function ComposerPane(props: ComposerPaneProps) {
   const [dragOver, setDragOver] = createSignal(false);
   const [showMemory, setShowMemory] = createSignal(false);
   const [showSkills, setShowSkills] = createSignal(false);
+  const COMPOSER_FONT_SIZES = [11, 12, 13, 14, 15, 16, 18, 20] as const;
+  const [composerFontSize, setComposerFontSize] = createSignal(13);
+
+  // Sticky progress indicator — shows last activity so user doesn't have to scroll
+  const [activityLabel, setActivityLabel] = createSignal('');
 
   // Slash command autocomplete
   const [commands, setCommands] = createSignal<ComposerCommand[]>([]);
@@ -232,10 +237,26 @@ export default function ComposerPane(props: ComposerPaneProps) {
   let feedRef: HTMLDivElement | undefined;
   let textareaRef: HTMLTextAreaElement | undefined;
 
-  const scrollToBottom = () => {
+  const SCROLL_THRESHOLD = 80;
+  const [userScrolledUp, setUserScrolledUp] = createSignal(false);
+
+  const isNearBottom = (): boolean => {
+    if (!feedRef) return true;
+    return feedRef.scrollHeight - feedRef.scrollTop - feedRef.clientHeight < SCROLL_THRESHOLD;
+  };
+
+  const scrollToBottom = (force = false) => {
     requestAnimationFrame(() => {
-      if (feedRef) feedRef.scrollTop = feedRef.scrollHeight;
+      if (!feedRef) return;
+      if (force || !userScrolledUp()) {
+        feedRef.scrollTop = feedRef.scrollHeight;
+        setUserScrolledUp(false);
+      }
     });
+  };
+
+  const handleFeedScroll = () => {
+    setUserScrolledUp(!isNearBottom());
   };
 
   // ── Rehydration helpers ──────────────────────────────────────────────
@@ -407,6 +428,10 @@ export default function ComposerPane(props: ComposerPaneProps) {
     void loadPref('composer_auto_accept_edits').then((val) => {
       if (val === 'false') setAutoAccept(false);
     });
+    void loadPref('composer_font_size').then((val) => {
+      const n = Number(val);
+      if (n && COMPOSER_FONT_SIZES.includes(n as any)) setComposerFontSize(n);
+    });
 
     // Kick off the sessions list in parallel — doesn't block history load.
     void refreshSessions();
@@ -460,6 +485,19 @@ export default function ComposerPane(props: ComposerPaneProps) {
     }
 
     console.log('[Composer] live event:', ev.type, ev);
+
+    // Update sticky progress label
+    switch (ev.type) {
+      case 'thinking': setActivityLabel('Thinking...'); break;
+      case 'delta': setActivityLabel('Writing response...'); break;
+      case 'tool_use': {
+        const summary = extractToolSummary(ev.tool_name ?? 'tool', ev.tool_input ?? '{}');
+        setActivityLabel(`${ev.tool_name} — ${summary.label}`);
+        break;
+      }
+      case 'tool_result': setActivityLabel('Processing result...'); break;
+      case 'done': case 'error': setActivityLabel(''); break;
+    }
 
     const turnId = ev.turn_id ?? activeTurnId();
     if (!turnId) return;
@@ -1185,7 +1223,7 @@ export default function ComposerPane(props: ComposerPaneProps) {
       </Show>
 
       {/* Conversation feed */}
-      <div class={styles.feed} ref={feedRef}>
+      <div class={styles.feed} ref={feedRef} onScroll={handleFeedScroll} style={{ 'font-size': `${composerFontSize()}px` }}>
         <Show when={turns.length === 0}>
           <div class={styles.emptyState}>
             Ask Composer to make changes across files. Try{' '}
@@ -1290,10 +1328,22 @@ export default function ComposerPane(props: ComposerPaneProps) {
         </For>
       </div>
 
-      {/* Composer / textarea / model picker / send hint.
-          Drag-drop accepts both Finder files (DataTransfer.files[].path)
-          and internal sidebar drags (text/phantom-path mime). Each dropped
-          item lands as a fresh @mention chip. */}
+      <Show when={userScrolledUp() && running()}>
+        <button
+          class={styles.jumpToLatest}
+          type="button"
+          onClick={() => scrollToBottom(true)}
+        >
+          ↓ Jump to latest
+        </button>
+      </Show>
+
+      <Show when={running() && activityLabel()}>
+        <div class={styles.progressStrip}>
+          <span class={styles.progressDot} />
+          <span class={styles.progressLabel}>{activityLabel()}</span>
+        </div>
+      </Show>
       <div
         class={`${styles.composerArea} ${dragOver() ? styles.composerAreaDragOver : ''}`}
         onDragOver={handleDragOver}
@@ -1437,6 +1487,38 @@ export default function ComposerPane(props: ComposerPaneProps) {
                   const label = EFFORTS.find((e) => e.value === state.selectedOption())?.label ?? state.selectedOption();
                   return `Effort: ${label}`;
                 }}
+              </Select.Value>
+              <Select.Icon class={styles.modelSelectIcon}>
+                <ChevronDown size={12} />
+              </Select.Icon>
+            </Select.Trigger>
+            <Select.Portal>
+              <Select.Content class={styles.modelSelectContent}>
+                <Select.Listbox class={styles.modelSelectListbox} />
+              </Select.Content>
+            </Select.Portal>
+          </Select>
+
+          <Select<string>
+            value={String(composerFontSize())}
+            onChange={(val) => {
+              if (val === null) return;
+              const n = Number(val);
+              setComposerFontSize(n);
+              void setPref('composer_font_size', String(n));
+            }}
+            options={COMPOSER_FONT_SIZES.map(String)}
+            itemComponent={(itemProps) => (
+              <Select.Item item={itemProps.item} class={styles.modelSelectItem}>
+                <Select.ItemLabel class={styles.modelSelectItemLabel}>
+                  {itemProps.item.rawValue}px
+                </Select.ItemLabel>
+              </Select.Item>
+            )}
+          >
+            <Select.Trigger class={styles.modelSelectTrigger} title="Composer font size">
+              <Select.Value<string> class={styles.modelSelectValue}>
+                {(state) => `${state.selectedOption()}px`}
               </Select.Value>
               <Select.Icon class={styles.modelSelectIcon}>
                 <ChevronDown size={12} />

--- a/v2/frontend/src/core/bindings/composer.ts
+++ b/v2/frontend/src/core/bindings/composer.ts
@@ -278,3 +278,24 @@ export async function composerListSkills(cwd: string): Promise<ComposerSkill[]> 
     return [];
   }
 }
+
+// ── Slash command autocomplete ───────────────────────────────────────
+
+export interface ComposerCommand {
+  name: string;
+  description: string;
+  argument_hint: string;
+  model: string;
+  allowed_tools: string;
+  source: string; // "project" | "global" | "plugin:<name>"
+  file_path: string;
+}
+
+export async function composerListCommands(cwd: string): Promise<ComposerCommand[]> {
+  try {
+    const raw = (await App()?.ComposerListCommands(cwd)) ?? [];
+    return normalize<ComposerCommand[]>(raw);
+  } catch {
+    return [];
+  }
+}

--- a/v2/frontend/src/shared/SettingsDialog/SettingsDialog.css.ts
+++ b/v2/frontend/src/shared/SettingsDialog/SettingsDialog.css.ts
@@ -81,8 +81,8 @@ export const settingDescription = style({
 
 export const themeGrid = style({
   display: 'grid',
-  gridTemplateColumns: 'repeat(4, 1fr)',
-  gap: vars.space.md,
+  gridTemplateColumns: 'repeat(6, 1fr)',
+  gap: vars.space.xs,
 });
 
 export const themeSwatch = style({
@@ -90,12 +90,12 @@ export const themeSwatch = style({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
-  gap: vars.space.xs,
+  gap: '2px',
   cursor: 'pointer',
   background: 'transparent',
   border: 'none',
-  padding: vars.space.sm,
-  borderRadius: vars.radius.md,
+  padding: vars.space.xs,
+  borderRadius: vars.radius.sm,
   transition: `all ${vars.animation.fast} ease`,
   selectors: {
     '&:hover': {
@@ -152,9 +152,10 @@ globalStyle(`${themeSelectedLabel} > strong`, {
 
 export const themeSwatchLabel = style({
   fontFamily: vars.font.body,
-  fontSize: vars.fontSize.xs,
+  fontSize: '9px',
   color: vars.color.textSecondary,
   textAlign: 'center',
+  lineHeight: 1.2,
 });
 
 export const segmentedControl = style({
@@ -237,8 +238,8 @@ export const settingGroupHeader = style({
 });
 
 export const themeSwatchCircle = style({
-  width: '32px',
-  height: '32px',
+  width: '22px',
+  height: '22px',
   borderRadius: vars.radius.full,
   border: `2px solid ${vars.color.border}`,
   transition: `all ${vars.animation.fast} ease`,

--- a/v2/frontend/src/shared/SettingsDialog/sections/AppearanceSection.tsx
+++ b/v2/frontend/src/shared/SettingsDialog/sections/AppearanceSection.tsx
@@ -146,6 +146,25 @@ export default function AppearanceSection() {
         </div>
       </div>
 
+      {/* Font Size */}
+      <div class={styles.settingGroup}>
+        <span class={styles.settingGroupHeader}>
+          Font Size · {Math.round(16 * (ZOOM_LEVELS.find(z => z.id === activeZoom())?.scale ?? 1))}px
+        </span>
+        <input
+          type="range"
+          class={styles.sliderInput}
+          min={0}
+          max={ZOOM_LEVELS.length - 1}
+          step={1}
+          value={ZOOM_LEVELS.findIndex(z => z.id === activeZoom())}
+          onInput={(e) => {
+            const idx = Number(e.currentTarget.value);
+            if (ZOOM_LEVELS[idx]) applyZoom(ZOOM_LEVELS[idx].id as ZoomLevelId);
+          }}
+        />
+      </div>
+
       {/* Brightness */}
       <div class={styles.settingGroup}>
         <span class={styles.settingGroupHeader}>Brightness · {activeBrightness()}%</span>

--- a/v2/internal/app/bindings_composer.go
+++ b/v2/internal/app/bindings_composer.go
@@ -244,6 +244,14 @@ func (a *App) ComposerGetMemoryContext(cwd string) []map[string]interface{} {
 	return result
 }
 
+// ComposerListCommands returns all available slash commands for the given cwd.
+// Scans project (.claude/commands/), global (~/.claude/commands/), and
+// installed plugin command directories. Used by the Composer input to power
+// slash-command autocomplete.
+func (a *App) ComposerListCommands(cwd string) []composer.Command {
+	return composer.DiscoverCommands(cwd)
+}
+
 // ComposerListPending returns all pending edit cards for a pane (used on
 // pane mount to repopulate cards after a refresh / app restart).
 func (a *App) ComposerListPending(paneID string) []composer.Edit {

--- a/v2/internal/composer/commands.go
+++ b/v2/internal/composer/commands.go
@@ -1,0 +1,176 @@
+// Author: Subash Karki
+package composer
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Command represents a discovered slash command from a .md file with optional
+// YAML frontmatter. Serialized to JSON for the Solid frontend.
+type Command struct {
+	Name         string `json:"name"`
+	Description  string `json:"description"`
+	ArgumentHint string `json:"argument_hint"`
+	Model        string `json:"model"`
+	AllowedTools string `json:"allowed_tools"`
+	Source       string `json:"source"` // "project", "global", "plugin:<name>"
+	FilePath     string `json:"file_path"`
+	Body         string `json:"-"` // markdown body, not serialized to frontend
+}
+
+type commandFrontmatter struct {
+	Description            string `yaml:"description"`
+	ArgumentHint           string `yaml:"argument-hint"`
+	Model                  string `yaml:"model"`
+	AllowedTools           string `yaml:"allowed-tools"`
+	HideFromSlashCommand   string `yaml:"hide-from-slash-command-tool"`
+	DisableModelInvocation string `yaml:"disable-model-invocation"`
+}
+
+// DiscoverCommands scans project, global, and plugin directories for .md
+// command files and returns them as a flat slice. The order is project →
+// global → plugins so callers that want "first match wins" get project
+// commands with highest priority.
+func DiscoverCommands(cwd string) []Command {
+	var cmds []Command
+
+	home, _ := os.UserHomeDir()
+
+	// 1. Project-level: <cwd>/.claude/commands/
+	if cwd != "" {
+		projectDir := filepath.Join(cwd, ".claude", "commands")
+		cmds = append(cmds, scanCommandDir(projectDir, "project")...)
+	}
+
+	// 2. Global user-level: ~/.claude/commands/
+	if home != "" {
+		globalDir := filepath.Join(home, ".claude", "commands")
+		cmds = append(cmds, scanCommandDir(globalDir, "global")...)
+	}
+
+	// 3. Installed plugins: ~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/commands/
+	if home != "" {
+		pluginCache := filepath.Join(home, ".claude", "plugins", "cache")
+		if info, err := os.Stat(pluginCache); err == nil && info.IsDir() {
+			marketplaces, _ := os.ReadDir(pluginCache)
+			for _, mp := range marketplaces {
+				if !mp.IsDir() {
+					continue
+				}
+				plugins, _ := os.ReadDir(filepath.Join(pluginCache, mp.Name()))
+				for _, plug := range plugins {
+					if !plug.IsDir() {
+						continue
+					}
+					versions, _ := os.ReadDir(filepath.Join(pluginCache, mp.Name(), plug.Name()))
+					for _, ver := range versions {
+						if !ver.IsDir() {
+							continue
+						}
+						cmdDir := filepath.Join(pluginCache, mp.Name(), plug.Name(), ver.Name(), "commands")
+						source := "plugin:" + plug.Name()
+						cmds = append(cmds, scanCommandDir(cmdDir, source)...)
+					}
+				}
+			}
+		}
+	}
+
+	return cmds
+}
+
+// scanCommandDir walks a directory tree looking for .md files and parses each
+// into a Command. Returns nil when the directory doesn't exist.
+func scanCommandDir(dir, source string) []Command {
+	var cmds []Command
+	if _, err := os.Stat(dir); err != nil {
+		return nil
+	}
+	_ = filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(d.Name(), ".md") {
+			return nil
+		}
+		cmd, parseErr := parseCommandFile(path, source, dir)
+		if parseErr != nil {
+			return nil
+		}
+		cmds = append(cmds, cmd)
+		return nil
+	})
+	return cmds
+}
+
+// parseCommandFile reads a single .md command file, extracts optional YAML
+// frontmatter, and returns a Command. Returns an error for hidden commands
+// or unreadable files.
+func parseCommandFile(path, source, baseDir string) (Command, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Command{}, err
+	}
+	content := string(data)
+
+	// Derive name from relative path: commands/team/status.md → team:status
+	rel, _ := filepath.Rel(baseDir, path)
+	name := strings.TrimSuffix(rel, ".md")
+	name = strings.ReplaceAll(name, string(filepath.Separator), ":")
+
+	// For plugin commands, prefix with plugin name from source
+	if strings.HasPrefix(source, "plugin:") {
+		plugName := strings.TrimPrefix(source, "plugin:")
+		if name != plugName && !strings.HasPrefix(name, plugName+":") {
+			name = plugName + ":" + name
+		}
+	}
+
+	var fm commandFrontmatter
+	body := content
+
+	// Parse YAML frontmatter between --- delimiters
+	if strings.HasPrefix(strings.TrimSpace(content), "---") {
+		parts := strings.SplitN(content, "---", 3)
+		if len(parts) >= 3 {
+			_ = yaml.Unmarshal([]byte(parts[1]), &fm)
+			body = strings.TrimSpace(parts[2])
+		}
+	}
+
+	if fm.HideFromSlashCommand == "true" {
+		return Command{}, fmt.Errorf("hidden command")
+	}
+
+	return Command{
+		Name:         name,
+		Description:  fm.Description,
+		ArgumentHint: fm.ArgumentHint,
+		Model:        fm.Model,
+		AllowedTools: fm.AllowedTools,
+		Source:       source,
+		FilePath:     path,
+		Body:         body,
+	}, nil
+}
+
+// ResolveCommand finds a command by name and returns its rendered body with
+// $ARGUMENTS substituted. Returns empty strings if not found.
+func ResolveCommand(cwd, name, arguments string) (string, string) {
+	cmds := DiscoverCommands(cwd)
+	for _, cmd := range cmds {
+		if cmd.Name == name {
+			body := cmd.Body
+			body = strings.ReplaceAll(body, "$ARGUMENTS", arguments)
+			// Resolve $CLAUDE_PLUGIN_ROOT for plugin commands
+			if strings.HasPrefix(cmd.Source, "plugin:") {
+				pluginRoot := filepath.Dir(filepath.Dir(cmd.FilePath))
+				body = strings.ReplaceAll(body, "$CLAUDE_PLUGIN_ROOT", pluginRoot)
+			}
+			return body, cmd.Model
+		}
+	}
+	return "", ""
+}

--- a/v2/internal/composer/service.go
+++ b/v2/internal/composer/service.go
@@ -162,6 +162,24 @@ func (s *Service) Send(ctx context.Context, args SendArgs) (string, error) {
 		args.Model = defaultModel
 	}
 
+	// Resolve slash commands: /command-name args → command markdown body.
+	// Must happen before prompt is consumed by buildPromptWithMentions so the
+	// CLI sees the expanded command body, not the raw "/foo" shorthand.
+	if strings.HasPrefix(strings.TrimSpace(args.Prompt), "/") {
+		parts := strings.SplitN(strings.TrimSpace(args.Prompt), " ", 2)
+		cmdName := strings.TrimPrefix(parts[0], "/")
+		cmdArgs := ""
+		if len(parts) > 1 {
+			cmdArgs = parts[1]
+		}
+		if resolved, cmdModel := ResolveCommand(args.CWD, cmdName, cmdArgs); resolved != "" {
+			args.Prompt = resolved
+			if cmdModel != "" {
+				args.Model = cmdModel
+			}
+		}
+	}
+
 	cliPath, err := ResolveClaudeBin()
 	if err != nil {
 		s.emit("composer:event", Event{PaneID: args.PaneID, Type: "error", Content: "claude CLI not found in PATH"})
@@ -1040,7 +1058,9 @@ func (s *Service) maybeRecordEdit(ctx context.Context, paneID, turnID, cwd, tool
 		if json.Unmarshal(input, &w) != nil || w.FilePath == "" {
 			return
 		}
-		old, _ := readFileSafe(w.FilePath)
+		// The CLI writes the file before emitting tool_use, so readFileSafe
+		// returns the NEW content. Use git to get the pre-edit base.
+		old := gitShowHead(w.FilePath, cwd)
 		s.emitEdit(ctx, paneID, turnID, cwd, w.FilePath, old, w.Content)
 		s.trackConflictFile(paneID, cwd, w.FilePath)
 
@@ -1349,6 +1369,40 @@ func buildPromptWithMentions(prompt string, mentions []Mention, cwd string) stri
 	sb.WriteString("USER:\n")
 	sb.WriteString(prompt)
 	return sb.String()
+}
+
+// gitShowHead returns the file content at HEAD using git show. Falls back to
+// empty string for untracked files or when git isn't available. Used to get
+// the pre-edit baseline for Write operations where the CLI writes the file
+// before emitting the tool_use event.
+func gitShowHead(filePath, cwd string) string {
+	if filePath == "" {
+		return ""
+	}
+	absPath := filePath
+	if !filepath.IsAbs(filePath) && cwd != "" {
+		absPath = filepath.Join(cwd, filePath)
+	}
+	dir := filepath.Dir(absPath)
+	// Get the path relative to the git repo root
+	rootCmd := exec.Command("git", "-c", "core.optionalLocks=false", "rev-parse", "--show-toplevel")
+	rootCmd.Dir = dir
+	rootOut, err := rootCmd.Output()
+	if err != nil {
+		return ""
+	}
+	repoRoot := strings.TrimSpace(string(rootOut))
+	rel, err := filepath.Rel(repoRoot, absPath)
+	if err != nil {
+		return ""
+	}
+	cmd := exec.Command("git", "-c", "core.optionalLocks=false", "show", "HEAD:"+rel)
+	cmd.Dir = repoRoot
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return string(out)
 }
 
 func readFileSafe(path string) (string, error) {


### PR DESCRIPTION
## Summary
- **Slash command autocomplete**: Type `/` in the Composer textarea to see all available commands from project (`.claude/commands/`), global (`~/.claude/commands/`), and installed plugins (`~/.claude/plugins/cache/`). Arrow keys + Enter to select. Commands resolve to their markdown body with `$ARGUMENTS` substitution.
- **Diff card fix**: Write operations now use `git show HEAD:<path>` to get the pre-edit baseline, fixing the +0 -0 diff display issue.
- **Auto-accept by default**: Composer starts in auto-accept mode. Users can toggle off via the toolbar pill.
- **Collapsed diffs**: Diff cards start collapsed (header-only with filename + stats). Click chevron to expand.

## Changed files
| File | What |
|------|------|
| `commands.go` (NEW) | Command discovery, frontmatter parsing, resolution |
| `bindings_composer.go` | `ComposerListCommands` binding |
| `service.go` | Slash command interception in Send, `gitShowHead` helper |
| `composer.ts` | `ComposerCommand` type + binding |
| `ComposerPane.tsx` | Autocomplete UI, auto-accept default, command state |
| `ComposerPane.css.ts` | Command palette styles |
| `ComposerDiffCard.tsx` | Default collapsed state |

## Test plan
- [x] Type `/` in composer → see ~95 commands with descriptions and source badges
- [x] Select a command → inserts `/<name> ` into input
- [x] Send `/team:status` → resolves to markdown body and executes
- [x] Trigger a Write edit → diff card shows proper green/red highlighting (not +0 -0)
- [x] New composer pane starts in auto-accept mode
- [x] Diff cards start collapsed, expand on click

Closes #46

## Fun fact
The Claude Code CLI supports `$CLAUDE_PLUGIN_ROOT` variable substitution in plugin commands, which lets plugins reference their own scripts directory without knowing their install path — a pattern borrowed from Homebrew's `$HOMEBREW_PREFIX`.