### PR TITLE
fix(composer): sub-agent results now render correctly

### DIFF
--- a/v2/frontend/src/components/panes/ComposerPane.tsx
+++ b/v2/frontend/src/components/panes/ComposerPane.tsx
@@ -281,7 +281,7 @@ interface TurnView {
   prompt: string;
   text: string;
   thinking: string;
-  toolUses: { name: string; input: string; status: 'running' | 'done' | 'error'; result?: string; resultIsError?: boolean }[];
+  toolUses: { toolUseId?: string; name: string; input: string; status: 'running' | 'done' | 'error'; result?: string; resultIsError?: boolean }[];
   editIds: string[];
   status: 'running' | 'done' | 'error' | 'cancelled';
   error?: string;
@@ -848,8 +848,9 @@ export default function ComposerPane(props: ComposerPaneProps) {
           for (const tu of turn.toolUses) {
             if (tu.status === 'running') tu.status = 'done';
           }
-          // Append the new tool use.
+          // Append the new tool use with ID for reliable result matching.
           turn.toolUses.push({
+            toolUseId: ev.tool_use_id,
             name: ev.tool_name ?? 'tool',
             input: ev.tool_input ?? '',
             status: 'running',
@@ -869,7 +870,14 @@ export default function ComposerPane(props: ComposerPaneProps) {
         break;
       }
       case 'tool_result': {
-        const tuIdx = turns[idx].toolUses.findLastIndex(u => u.status === 'running');
+        // Match by tool_use_id when available (reliable for async agents),
+        // fall back to last running tool (legacy sequential behavior).
+        let tuIdx = ev.tool_use_id
+          ? turns[idx].toolUses.findIndex(u => u.toolUseId === ev.tool_use_id)
+          : -1;
+        if (tuIdx < 0) {
+          tuIdx = turns[idx].toolUses.findLastIndex(u => u.status === 'running');
+        }
         if (tuIdx >= 0) {
           setTurns(idx, 'toolUses', tuIdx, produce(tu => {
             tu.result = ev.content ?? '';
@@ -2236,7 +2244,7 @@ function ThinkingChip(props: { content: string }) {
 
 /** Section wrapper for tool calls with expand-all / collapse-all toggle + grouping. */
 function ToolCallsSection(props: {
-  toolUses: { name: string; input: string; status: 'running' | 'done' | 'error'; result?: string; resultIsError?: boolean }[];
+  toolUses: { toolUseId?: string; name: string; input: string; status: 'running' | 'done' | 'error'; result?: string; resultIsError?: boolean }[];
 }) {
   const [expandMode, setExpandMode] = createSignal<'all' | 'none' | 'individual'>('individual');
 

--- a/v2/internal/composer/service.go
+++ b/v2/internal/composer/service.go
@@ -1119,6 +1119,7 @@ func (s *Service) handleAssistant(ctx context.Context, paneID, turnID, cwd strin
 			Type     string          `json:"type"`
 			Text     string          `json:"text,omitempty"`
 			Thinking string          `json:"thinking,omitempty"`
+			ID       string          `json:"id,omitempty"`
 			Name     string          `json:"name,omitempty"`
 			Input    json.RawMessage `json:"input,omitempty"`
 		} `json:"content"`
@@ -1151,6 +1152,7 @@ func (s *Service) handleAssistant(ctx context.Context, paneID, turnID, cwd strin
 				Type:      "tool_use",
 				ToolName:  block.Name,
 				ToolInput: string(block.Input),
+				ToolUseID: block.ID,
 			})
 			s.maybeRecordEdit(ctx, paneID, turnID, cwd, block.Name, block.Input)
 		}


### PR DESCRIPTION
## Summary

- Sub-agent (Agent tool) results were silently dropped in the Composer UI
- Root cause: tool_result matched by position (`findLastIndex(status=running)`) not by `tool_use_id`
- Async agent results arrive out of order → matched wrong tool or dropped

## Fixes

- **Backend** (`service.go`): `handleAssistant()` now includes `block.ID` as `ToolUseID` in tool_use events
- **Frontend** (`ComposerPane.tsx`): tool_result matches by `ev.tool_use_id` first, falls back to last-running for legacy

## Test plan

- [x] Go build passes
- [ ] Send prompt that spawns Agent tools → results should render in correct tool_use chip
- [ ] Synchronous tools (Bash, Read, Edit) still work (fallback path)
- [ ] Background agents (`run_in_background: true`) render results when they complete

## Fun fact

This bug meant every Agent tool call in Composer was visually broken since launch. Results existed but were matched to the wrong chip or silently swallowed.