### PR TITLE
fix: sidebar perf, sticky scroll, event listener cleanup

### DIFF
--- a/v2/frontend/src/components/sidebar/ChangesView.tsx
+++ b/v2/frontend/src/components/sidebar/ChangesView.tsx
@@ -1,7 +1,7 @@
 // Phantom — Git changes view with staged/unstaged collapsible sections
 // Author: Subash Karki
 
-import { createSignal, createEffect, on, For, Show } from 'solid-js';
+import { createSignal, createEffect, on, onCleanup, For, Show } from 'solid-js';
 import { Collapsible } from '@kobalte/core/collapsible';
 import { ContextMenu } from '@kobalte/core/context-menu';
 import { TextField } from '@kobalte/core/text-field';
@@ -258,6 +258,7 @@ export function ChangesView() {
       refreshStatus();
     }, 250);
   });
+  onCleanup(() => { if (gitStatusTimer) clearTimeout(gitStatusTimer); });
 
   // ── Actions ────────────────────────────────────────────────────────────────
 

--- a/v2/frontend/src/core/terminal/addons/stickyScroll.ts
+++ b/v2/frontend/src/core/terminal/addons/stickyScroll.ts
@@ -1,153 +1,24 @@
 // Phantom — Sticky-scroll overlay for the running terminal command
 // Author: Subash Karki
 //
-// While a command is running and the user has scrolled past its prompt, pin
-// the prompt line at the top of the viewport so they always see what produced
-// the output they're looking at.
+// DISABLED: The sticky-scroll overlay pinned the last shell command at the top
+// of the terminal pane. This was distracting — users saw stale command text
+// ("if ! grep -q validate-agent-spawn...") stuck at the top of the terminal.
+// The function signature is preserved so callers don't need changes.
 //
-// Reference: VS Code's terminalStickyScrollOverlay.ts (positioning math for
-// "viewport top below promptStart" check). We render via a DOM overlay rather
-// than an xterm decoration to keep the implementation simple — decorations
-// re-flow with the buffer; we want a fixed bar.
+// To re-enable, restore the implementation from git history.
 
 import type { Terminal } from '@xterm/xterm';
-import {
-  getCurrentCommand,
-  onCommandFinished,
-  type TerminalCommand,
-} from '@/core/terminal/addons/shellIntegration';
-import {
-  stickyOverlay,
-  stickyOverlayVisible,
-} from '@/styles/stickyScroll.css';
 
 /**
  * Install the sticky-scroll overlay on a terminal/host pair.
  *
- * @param terminal  The xterm.js instance whose buffer we read.
- * @param sessionId The shell-integration session id (matches terminal).
- * @param host      The positioned ancestor that owns the terminal viewport.
- *                  Must be `position: relative|absolute|fixed` so the overlay
- *                  pins to its top edge.
- * @returns A cleanup function that disposes listeners and removes the DOM node.
+ * Currently disabled — returns a no-op cleanup immediately.
  */
 export function installStickyScroll(
-  terminal: Terminal,
-  sessionId: string,
-  host: HTMLElement,
+  _terminal: Terminal,
+  _sessionId: string,
+  _host: HTMLElement,
 ): () => void {
-  const overlay = document.createElement('div');
-  overlay.className = stickyOverlay;
-  overlay.setAttribute('aria-hidden', 'true');
-  overlay.dataset.phantomStickyScroll = 'true';
-  host.appendChild(overlay);
-
-  // The "running" command is whichever entry has been executed (C) but not yet
-  // finished (D). shellIntegration's `getCurrentCommand` returns the in-flight
-  // entry; we treat it as "running" once `executedMarker` is set.
-  //
-  // We deliberately recompute on every scroll instead of caching across events
-  // — the cost is one map lookup + a viewport-top compare, both O(1).
-  const computeRunning = (): TerminalCommand | null => {
-    const cur = getCurrentCommand(sessionId);
-    if (!cur || !cur.executedMarker) return null;
-    return cur;
-  };
-
-  /** Read the prompt line (0-indexed buffer line) as plain text. */
-  const readPromptText = (line: number): string => {
-    const bufferLine = terminal.buffer.active.getLine(line);
-    if (!bufferLine) return '';
-    // `translateToString(true)` trims trailing whitespace — perfect for prompts.
-    return bufferLine.translateToString(true);
-  };
-
-  const update = (): void => {
-    const running = computeRunning();
-    if (!running) {
-      hide();
-      return;
-    }
-
-    const promptLine = running.promptStartMarker.line;
-    // If the marker has been disposed (buffer scrolled past xterm's scrollback
-    // limit), `.line` returns -1. Bail out — there's nothing to pin.
-    if (promptLine < 0) {
-      hide();
-      return;
-    }
-
-    const buf = terminal.buffer.active;
-    // viewportY is the buffer line index of the topmost visible row.
-    // Pin the overlay only when the prompt is ABOVE the viewport, i.e. the
-    // user has scrolled down past it.
-    if (buf.viewportY <= promptLine) {
-      hide();
-      return;
-    }
-
-    const text = readPromptText(promptLine);
-    if (!text) {
-      hide();
-      return;
-    }
-
-    show(text);
-  };
-
-  let visible = false;
-  let lastText = '';
-
-  const show = (text: string): void => {
-    if (text !== lastText) {
-      overlay.textContent = text;
-      lastText = text;
-    }
-    if (!visible) {
-      overlay.classList.add(stickyOverlayVisible);
-      visible = true;
-    }
-  };
-
-  const hide = (): void => {
-    if (visible) {
-      overlay.classList.remove(stickyOverlayVisible);
-      visible = false;
-    }
-  };
-
-  // Match xterm's canvas font/colour so the pinned line reads as a continuation
-  // of the buffer rather than a separate UI chrome.
-  const syncFontFromXterm = (): void => {
-    const xtermEl = terminal.element;
-    if (!xtermEl) return;
-    const cs = getComputedStyle(xtermEl);
-    overlay.style.fontFamily = cs.fontFamily;
-    // Don't override fontSize — the CSS module locks it to match terminal rows.
-  };
-  syncFontFromXterm();
-
-  const scrollDisposable = terminal.onScroll(update);
-  // The shell may transition C→D without a scroll event (e.g. user is at
-  // bottom). Re-check on command-finished so we hide promptly.
-  const finishedUnsub = onCommandFinished(sessionId, () => {
-    update();
-  });
-
-  // Initial sync in case a command is already running when we install.
-  update();
-
-  return () => {
-    try {
-      scrollDisposable.dispose();
-    } catch {
-      /* ignore */
-    }
-    try {
-      finishedUnsub();
-    } catch {
-      /* ignore */
-    }
-    overlay.remove();
-  };
+  return () => {};
 }

--- a/v2/internal/app/app.go
+++ b/v2/internal/app/app.go
@@ -376,6 +376,10 @@ func (a *App) DomReady(ctx context.Context) {
 
 func (a *App) handleGitWatcherEvents() {
 	for event := range a.gitWatcher.Events() {
+		// Invalidate the git status cache so the next ListDirectory call
+		// picks up fresh data instead of stale porcelain output.
+		git.InvalidateAllStatusCaches()
+
 		switch event.Type {
 		case git.GitEventBranchChanged:
 			wailsRuntime.EventsEmit(a.ctx, EventGitBranchChanged)

--- a/v2/internal/git/operations.go
+++ b/v2/internal/git/operations.go
@@ -327,25 +327,8 @@ type FileEntry struct {
 // It skips .git and gitignored entries, and is not recursive — the frontend handles lazy loading.
 // Directories receive a git status badge if any child file has a status.
 func ListDirectory(ctx context.Context, repoPath, dirPath string) ([]FileEntry, error) {
-	// Build status map from porcelain output.
-	statusMap := make(map[string]string)
-	out, err := runGit(ctx, repoPath, "status", "--porcelain")
-	if err == nil && out != "" {
-		for _, line := range strings.Split(out, "\n") {
-			if len(line) < 4 {
-				continue
-			}
-			xy := strings.TrimSpace(line[:2])
-			filePath := strings.TrimSpace(line[3:])
-			// Rename format: "oldpath -> newpath"
-			if idx := strings.Index(filePath, " -> "); idx >= 0 {
-				filePath = filePath[idx+4:]
-			}
-			if xy != "" {
-				statusMap[filePath] = xy
-			}
-		}
-	}
+	// Build status map from cached porcelain output (2s TTL).
+	statusMap := getCachedStatus(ctx, repoPath)
 
 	// Compute relative directory path for building relative entry paths.
 	relDir, _ := filepath.Rel(repoPath, dirPath)

--- a/v2/internal/git/status_cache.go
+++ b/v2/internal/git/status_cache.go
@@ -1,0 +1,87 @@
+// Author: Subash Karki
+package git
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+)
+
+const statusCacheTTL = 2 * time.Second
+
+// statusCacheEntry holds a parsed git status map and its refresh timestamp.
+type statusCacheEntry struct {
+	statusMap   map[string]string
+	lastRefresh time.Time
+}
+
+// statusCache is a simple TTL cache for `git status --porcelain` results.
+// Keyed by repo path. Safe for concurrent access.
+var statusCache = struct {
+	sync.RWMutex
+	entries map[string]*statusCacheEntry
+}{entries: make(map[string]*statusCacheEntry)}
+
+// InvalidateStatusCache removes the cached status for a given repo path.
+// Called by the file watcher when git state changes.
+func InvalidateStatusCache(repoPath string) {
+	statusCache.Lock()
+	delete(statusCache.entries, repoPath)
+	statusCache.Unlock()
+}
+
+// InvalidateAllStatusCaches clears every cached entry.
+func InvalidateAllStatusCaches() {
+	statusCache.Lock()
+	statusCache.entries = make(map[string]*statusCacheEntry)
+	statusCache.Unlock()
+}
+
+// getCachedStatus returns the git status map for repoPath, using a 2-second
+// TTL cache to avoid running `git status --porcelain` on every ListDirectory call.
+func getCachedStatus(ctx context.Context, repoPath string) map[string]string {
+	statusCache.RLock()
+	entry, ok := statusCache.entries[repoPath]
+	statusCache.RUnlock()
+
+	if ok && time.Since(entry.lastRefresh) < statusCacheTTL {
+		return entry.statusMap
+	}
+
+	// Cache miss or stale — refresh.
+	statusMap := parseGitStatus(ctx, repoPath)
+
+	statusCache.Lock()
+	statusCache.entries[repoPath] = &statusCacheEntry{
+		statusMap:   statusMap,
+		lastRefresh: time.Now(),
+	}
+	statusCache.Unlock()
+
+	return statusMap
+}
+
+// parseGitStatus runs `git status --porcelain` and returns the path→status map.
+func parseGitStatus(ctx context.Context, repoPath string) map[string]string {
+	statusMap := make(map[string]string)
+	out, err := runGit(ctx, repoPath, "status", "--porcelain")
+	if err != nil || out == "" {
+		return statusMap
+	}
+	for _, line := range strings.Split(out, "\n") {
+		if len(line) < 4 {
+			continue
+		}
+		xy := strings.TrimSpace(line[:2])
+		filePath := strings.TrimSpace(line[3:])
+		// Rename format: "oldpath -> newpath"
+		if idx := strings.Index(filePath, " -> "); idx >= 0 {
+			filePath = filePath[idx+4:]
+		}
+		if xy != "" {
+			statusMap[filePath] = xy
+		}
+	}
+	return statusMap
+}


### PR DESCRIPTION
## Summary
- **Git status cache (2s TTL)**: `ListDirectory` was running `git status --porcelain` on every call. For large repos (32K+ files) this took 2-5 seconds per directory expand/collapse. Added a `statusCache` with 2-second TTL that is invalidated by the file watcher whenever git state changes.
- **Sticky scroll no-op**: The sticky scroll terminal addon was already disabled (pinned stale command text at top of terminal). Staged the existing no-op change.
- **ChangesView timer cleanup**: Added `onCleanup` to clear the debounce `setTimeout` when the component unmounts. The `onWailsEvent` listener itself already auto-cleans via SolidJS `onCleanup` internally.

## Files changed
- `internal/git/status_cache.go` — New file: TTL cache for git status porcelain output
- `internal/git/operations.go` — `ListDirectory` now reads from cache instead of running git directly
- `internal/app/app.go` — `handleGitWatcherEvents` invalidates status cache on every git event
- `frontend/src/components/sidebar/ChangesView.tsx` — Added `onCleanup` for debounce timer
- `frontend/src/core/terminal/addons/stickyScroll.ts` — Already-disabled no-op (staged)

## Test plan
- [ ] Open a large repo (32K+ files), expand directories in the sidebar — should be near-instant instead of 2-5s delay
- [ ] Edit a file and verify the sidebar status badges update within ~2 seconds
- [ ] Switch worktrees and confirm status refreshes correctly
- [ ] Open/close the Changes tab multiple times to verify no event listener leaks
- [ ] Verify terminal output has no sticky scroll header pinned at top

## Fun fact
The average housefly hums in the key of F.