### PR TITLE
chore: gitignore agentdb.rvf runtime files

### DIFF
--- a/v2/.gitignore
+++ b/v2/.gitignore
@@ -34,3 +34,6 @@ vendor/
 .env
 .env.local
 .ai
+# AgentDB (claude-flow runtime files)
+agentdb.rvf
+agentdb.rvf.lock


### PR DESCRIPTION
Adds agentdb.rvf and agentdb.rvf.lock to .gitignore — these are claude-flow/AgentDB runtime files that shouldn't be tracked.