### PR TITLE
fix: enable macOptionIsMeta for native terminal key behavior

### DIFF
--- a/v2/frontend/src/core/terminal/registry.ts
+++ b/v2/frontend/src/core/terminal/registry.ts
@@ -94,6 +94,8 @@ export function createSession(
     letterSpacing: userPrefs.letterSpacing ?? 0.2,
     cursorBlink: true,
     cursorStyle: 'bar',
+    macOptionIsMeta: true,
+    macOptionClickForcesSelection: true,
     allowTransparency: true,
     theme: opts?.theme ?? {},
     scrollback: 500,


### PR DESCRIPTION
## Summary
- Set `macOptionIsMeta: true` on xterm.js Terminal — Option key now acts as Meta/Alt like a real macOS terminal
- Set `macOptionClickForcesSelection: true` — Option+click positions cursor in text
- Shift+Enter now works for newline (was requiring Option+Enter before)
- Option+B/F word jumping now works

## Test plan
- [ ] Shift+Enter inserts newline in terminal (e.g. in Claude Code prompts)
- [ ] Option+B/F jumps backward/forward by word
- [ ] Option+click selects text properly
- [ ] Regular Enter still sends command

PR Generated with AI

Co-Authored-By: AI