### PR TITLE
fix: reduce V2 bindings enrichment timeout from 15s to 2s

### DIFF
--- a/v2/internal/composer/bindings.go
+++ b/v2/internal/composer/bindings.go
@@ -224,8 +224,7 @@ func (b *Bindings) ComposerV2Send(req SendRequest) error {
 	}
 
 	// Reset the watchdog before enrichment so the CLI subprocess isn't killed
-	// while we're preparing the enriched prompt (enrichment can take 5-15s for
-	// long prompts with many code identifiers).
+	// while we're preparing the enriched prompt.
 	session.ResetWatchdog()
 
 	// Attempt AI engine strategy selection + prompt enrichment for user messages.
@@ -447,9 +446,11 @@ func (b *Bindings) persistStreamEvent(sessionID string, session *Session, ev Str
 // ContextInjector when orchestrator deps are not wired. Errors are silently
 // ignored so the send always succeeds even if the engine is unavailable.
 func (b *Bindings) tryEnrichAndEmitStrategy(session *Session, req SendRequest) json.RawMessage {
-	// Cap total enrichment time to prevent the watchdog race. If enrichment
-	// takes longer than this, fall through to sending the raw prompt.
-	enrichCtx, enrichCancel := context.WithTimeout(b.ctx, 15*time.Second)
+	// Cap total enrichment time to keep first-token latency low. If
+	// enrichment takes longer than this, fall through to sending the raw
+	// prompt. 2s is enough for warm caches; cold vector-store queries
+	// gracefully degrade to unenriched prompts.
+	enrichCtx, enrichCancel := context.WithTimeout(b.ctx, 2*time.Second)
 	defer enrichCancel()
 
 	// Parse the send payload to extract user message text.


### PR DESCRIPTION
## Summary
- Reduced `tryEnrichAndEmitStrategy` timeout from 15s to 2s in V2 Bindings path (`bindings.go`)
- This is the **actual code path** used by the Composer pane (stream-json UI) — the previous fix (PR #96) only fixed V1's `service.go` path
- Strategy monitor will now show events only when orchestrator completes within 2s; otherwise raw prompt is sent immediately

## Root cause
PR #96 made the V1 `service.go` orchestrator async, but the production Composer uses the V2 `Bindings` path which was still blocking for up to 15 seconds in `tryEnrichAndEmitStrategy` before spawning the Claude CLI.

## Test plan
- [ ] Composer responds within ~2s of prompt submission
- [ ] Strategy monitor shows events when orchestrator is fast
- [ ] When orchestrator is slow, raw prompt still reaches Claude without stalling

PR Generated with AI

Co-Authored-By: AI