### PR TITLE
fix: use INSERT OR REPLACE for terminal_sessions

### DIFF
--- a/v2/internal/db/journal.sql.go
+++ b/v2/internal/db/journal.sql.go
@@ -39,7 +39,7 @@ func (q *Queries) GetDailyStats(ctx context.Context, arg GetDailyStatsParams) (D
 }
 
 const getLastActiveSession = `-- name: GetLastActiveSession :one
-SELECT id, pid, cwd, repo, name, kind, model, entrypoint, started_at, ended_at, status, task_count, completed_tasks, xp_earned, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, estimated_cost_micros, message_count, tool_use_count, first_prompt, tool_breakdown, last_input_tokens, context_used_pct, date, summary, outcome, files_touched, git_commits, git_lines_added, git_lines_removed, branch, pr_url, pr_status, provider, session_goal, session_type, tool_summary, keywords, parent_session_id FROM sessions WHERE status IN ('active', 'completed') ORDER BY started_at DESC LIMIT 1
+SELECT id, pid, cwd, repo, name, kind, model, entrypoint, started_at, ended_at, status, task_count, completed_tasks, xp_earned, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, estimated_cost_micros, message_count, tool_use_count, first_prompt, tool_breakdown, last_input_tokens, context_used_pct, date, summary, outcome, files_touched, git_commits, git_lines_added, git_lines_removed, branch, pr_url, pr_status, provider, session_goal, session_type, tool_summary, keywords, parent_session_id, session_profile FROM sessions WHERE status IN ('active', 'completed') ORDER BY started_at DESC LIMIT 1
 `
 
 func (q *Queries) GetLastActiveSession(ctx context.Context) (Session, error) {
@@ -87,13 +87,14 @@ func (q *Queries) GetLastActiveSession(ctx context.Context) (Session, error) {
 		&i.ToolSummary,
 		&i.Keywords,
 		&i.ParentSessionID,
+		&i.SessionProfile,
 	)
 	return i, err
 }
 
 const getSessionJournal = `-- name: GetSessionJournal :one
 
-SELECT id, pid, cwd, repo, name, kind, model, entrypoint, started_at, ended_at, status, task_count, completed_tasks, xp_earned, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, estimated_cost_micros, message_count, tool_use_count, first_prompt, tool_breakdown, last_input_tokens, context_used_pct, date, summary, outcome, files_touched, git_commits, git_lines_added, git_lines_removed, branch, pr_url, pr_status, provider, session_goal, session_type, tool_summary, keywords, parent_session_id FROM sessions WHERE id = ?
+SELECT id, pid, cwd, repo, name, kind, model, entrypoint, started_at, ended_at, status, task_count, completed_tasks, xp_earned, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, estimated_cost_micros, message_count, tool_use_count, first_prompt, tool_breakdown, last_input_tokens, context_used_pct, date, summary, outcome, files_touched, git_commits, git_lines_added, git_lines_removed, branch, pr_url, pr_status, provider, session_goal, session_type, tool_summary, keywords, parent_session_id, session_profile FROM sessions WHERE id = ?
 `
 
 // journal.sql - Activity Journal queries for sessions and daily stats
@@ -143,6 +144,7 @@ func (q *Queries) GetSessionJournal(ctx context.Context, id string) (Session, er
 		&i.ToolSummary,
 		&i.Keywords,
 		&i.ParentSessionID,
+		&i.SessionProfile,
 	)
 	return i, err
 }
@@ -237,7 +239,7 @@ func (q *Queries) ListDailyStatsRangeByProject(ctx context.Context, arg ListDail
 }
 
 const listRecentSessions = `-- name: ListRecentSessions :many
-SELECT id, pid, cwd, repo, name, kind, model, entrypoint, started_at, ended_at, status, task_count, completed_tasks, xp_earned, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, estimated_cost_micros, message_count, tool_use_count, first_prompt, tool_breakdown, last_input_tokens, context_used_pct, date, summary, outcome, files_touched, git_commits, git_lines_added, git_lines_removed, branch, pr_url, pr_status, provider, session_goal, session_type, tool_summary, keywords, parent_session_id FROM sessions WHERE status IN ('completed', 'active') ORDER BY started_at DESC LIMIT ?
+SELECT id, pid, cwd, repo, name, kind, model, entrypoint, started_at, ended_at, status, task_count, completed_tasks, xp_earned, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, estimated_cost_micros, message_count, tool_use_count, first_prompt, tool_breakdown, last_input_tokens, context_used_pct, date, summary, outcome, files_touched, git_commits, git_lines_added, git_lines_removed, branch, pr_url, pr_status, provider, session_goal, session_type, tool_summary, keywords, parent_session_id, session_profile FROM sessions WHERE status IN ('completed', 'active') ORDER BY started_at DESC LIMIT ?
 `
 
 func (q *Queries) ListRecentSessions(ctx context.Context, limit int64) ([]Session, error) {
@@ -291,6 +293,7 @@ func (q *Queries) ListRecentSessions(ctx context.Context, limit int64) ([]Sessio
 			&i.ToolSummary,
 			&i.Keywords,
 			&i.ParentSessionID,
+			&i.SessionProfile,
 		); err != nil {
 			return nil, err
 		}
@@ -306,7 +309,7 @@ func (q *Queries) ListRecentSessions(ctx context.Context, limit int64) ([]Sessio
 }
 
 const listSessionsByDate = `-- name: ListSessionsByDate :many
-SELECT id, pid, cwd, repo, name, kind, model, entrypoint, started_at, ended_at, status, task_count, completed_tasks, xp_earned, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, estimated_cost_micros, message_count, tool_use_count, first_prompt, tool_breakdown, last_input_tokens, context_used_pct, date, summary, outcome, files_touched, git_commits, git_lines_added, git_lines_removed, branch, pr_url, pr_status, provider, session_goal, session_type, tool_summary, keywords, parent_session_id FROM sessions WHERE date = ? ORDER BY started_at DESC
+SELECT id, pid, cwd, repo, name, kind, model, entrypoint, started_at, ended_at, status, task_count, completed_tasks, xp_earned, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, estimated_cost_micros, message_count, tool_use_count, first_prompt, tool_breakdown, last_input_tokens, context_used_pct, date, summary, outcome, files_touched, git_commits, git_lines_added, git_lines_removed, branch, pr_url, pr_status, provider, session_goal, session_type, tool_summary, keywords, parent_session_id, session_profile FROM sessions WHERE date = ? ORDER BY started_at DESC
 `
 
 func (q *Queries) ListSessionsByDate(ctx context.Context, date sql.NullString) ([]Session, error) {
@@ -360,6 +363,7 @@ func (q *Queries) ListSessionsByDate(ctx context.Context, date sql.NullString) (
 			&i.ToolSummary,
 			&i.Keywords,
 			&i.ParentSessionID,
+			&i.SessionProfile,
 		); err != nil {
 			return nil, err
 		}
@@ -375,7 +379,7 @@ func (q *Queries) ListSessionsByDate(ctx context.Context, date sql.NullString) (
 }
 
 const listSessionsByProject = `-- name: ListSessionsByProject :many
-SELECT id, pid, cwd, repo, name, kind, model, entrypoint, started_at, ended_at, status, task_count, completed_tasks, xp_earned, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, estimated_cost_micros, message_count, tool_use_count, first_prompt, tool_breakdown, last_input_tokens, context_used_pct, date, summary, outcome, files_touched, git_commits, git_lines_added, git_lines_removed, branch, pr_url, pr_status, provider, session_goal, session_type, tool_summary, keywords, parent_session_id FROM sessions WHERE repo = ? ORDER BY started_at DESC LIMIT ?
+SELECT id, pid, cwd, repo, name, kind, model, entrypoint, started_at, ended_at, status, task_count, completed_tasks, xp_earned, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, estimated_cost_micros, message_count, tool_use_count, first_prompt, tool_breakdown, last_input_tokens, context_used_pct, date, summary, outcome, files_touched, git_commits, git_lines_added, git_lines_removed, branch, pr_url, pr_status, provider, session_goal, session_type, tool_summary, keywords, parent_session_id, session_profile FROM sessions WHERE repo = ? ORDER BY started_at DESC LIMIT ?
 `
 
 type ListSessionsByProjectParams struct {
@@ -434,6 +438,7 @@ func (q *Queries) ListSessionsByProject(ctx context.Context, arg ListSessionsByP
 			&i.ToolSummary,
 			&i.Keywords,
 			&i.ParentSessionID,
+			&i.SessionProfile,
 		); err != nil {
 			return nil, err
 		}

--- a/v2/internal/db/models.go
+++ b/v2/internal/db/models.go
@@ -28,6 +28,97 @@ type ActivityLog struct {
 	Provider  string         `json:"provider"`
 }
 
+type AiDecision struct {
+	ID         string          `json:"id"`
+	Goal       string          `json:"goal"`
+	StrategyID string          `json:"strategy_id"`
+	Confidence sql.NullFloat64 `json:"confidence"`
+	Complexity sql.NullString  `json:"complexity"`
+	Risk       sql.NullString  `json:"risk"`
+	CreatedAt  sql.NullTime    `json:"created_at"`
+}
+
+type AiEmbedding struct {
+	ID          string       `json:"id"`
+	MemoryType  string       `json:"memory_type"`
+	SourceID    string       `json:"source_id"`
+	TextContent string       `json:"text_content"`
+	Vector      []byte       `json:"vector"`
+	CreatedAt   sql.NullTime `json:"created_at"`
+	ExpiresAt   sql.NullTime `json:"expires_at"`
+}
+
+type AiOutcome struct {
+	ID            string         `json:"id"`
+	DecisionID    sql.NullString `json:"decision_id"`
+	Success       int64          `json:"success"`
+	FailureReason sql.NullString `json:"failure_reason"`
+	CreatedAt     sql.NullTime   `json:"created_at"`
+	Phase         string         `json:"phase"`
+}
+
+type ChatConversation struct {
+	ID          string         `json:"id"`
+	WorkspaceID sql.NullString `json:"workspace_id"`
+	Title       string         `json:"title"`
+	Model       sql.NullString `json:"model"`
+	CreatedAt   int64          `json:"created_at"`
+	UpdatedAt   int64          `json:"updated_at"`
+}
+
+type ChatMessage struct {
+	ID             string         `json:"id"`
+	ConversationID sql.NullString `json:"conversation_id"`
+	WorkspaceID    sql.NullString `json:"workspace_id"`
+	Role           string         `json:"role"`
+	Content        string         `json:"content"`
+	Model          sql.NullString `json:"model"`
+	CreatedAt      int64          `json:"created_at"`
+}
+
+type ComposerEdit struct {
+	ID           string         `json:"id"`
+	TurnID       string         `json:"turn_id"`
+	PaneID       string         `json:"pane_id"`
+	Path         string         `json:"path"`
+	OldContent   sql.NullString `json:"old_content"`
+	NewContent   sql.NullString `json:"new_content"`
+	LinesAdded   int64          `json:"lines_added"`
+	LinesRemoved int64          `json:"lines_removed"`
+	Status       string         `json:"status"`
+	CreatedAt    int64          `json:"created_at"`
+	DecidedAt    sql.NullInt64  `json:"decided_at"`
+}
+
+type ComposerEvent struct {
+	ID        int64          `json:"id"`
+	TurnID    string         `json:"turn_id"`
+	SessionID string         `json:"session_id"`
+	Seq       int64          `json:"seq"`
+	Type      string         `json:"type"`
+	Subtype   sql.NullString `json:"subtype"`
+	ToolName  sql.NullString `json:"tool_name"`
+	ToolUseID sql.NullString `json:"tool_use_id"`
+	Content   sql.NullString `json:"content"`
+	CreatedAt int64          `json:"created_at"`
+}
+
+type ComposerTurn struct {
+	ID             string         `json:"id"`
+	PaneID         string         `json:"pane_id"`
+	SessionID      string         `json:"session_id"`
+	Cwd            string         `json:"cwd"`
+	Prompt         string         `json:"prompt"`
+	Model          string         `json:"model"`
+	Status         string         `json:"status"`
+	InputTokens    int64          `json:"input_tokens"`
+	OutputTokens   int64          `json:"output_tokens"`
+	CostUsd        float64        `json:"cost_usd"`
+	StartedAt      int64          `json:"started_at"`
+	CompletedAt    sql.NullInt64  `json:"completed_at"`
+	ResponseText   sql.NullString `json:"response_text"`
+	WasInterrupted int64          `json:"was_interrupted"`
+}
 
 type CustomRecipe struct {
 	ID          string         `json:"id"`
@@ -65,6 +156,13 @@ type DailyStat struct {
 	TotalCommits      sql.NullInt64  `json:"total_commits"`
 	PrCount           sql.NullInt64  `json:"pr_count"`
 	TopFiles          sql.NullString `json:"top_files"`
+}
+
+type ExtractionOffset struct {
+	SessionID       string `json:"session_id"`
+	ByteOffset      int64  `json:"byte_offset"`
+	EventCount      int64  `json:"event_count"`
+	LastExtractedAt int64  `json:"last_extracted_at"`
 }
 
 type GraphEdge struct {
@@ -194,6 +292,7 @@ type Session struct {
 	ToolSummary         sql.NullString `json:"tool_summary"`
 	Keywords            sql.NullString `json:"keywords"`
 	ParentSessionID     sql.NullString `json:"parent_session_id"`
+	SessionProfile      sql.NullString `json:"session_profile"`
 }
 
 type SessionEvent struct {
@@ -227,20 +326,21 @@ type Task struct {
 }
 
 type TerminalSession struct {
-	PaneID       string         `json:"pane_id"`
-	WorktreeID   sql.NullString `json:"worktree_id"`
-	Shell        sql.NullString `json:"shell"`
-	Cwd          sql.NullString `json:"cwd"`
-	Env          sql.NullString `json:"env"`
-	Cols         sql.NullInt64  `json:"cols"`
-	Rows         sql.NullInt64  `json:"rows"`
-	Scrollback   sql.NullString `json:"scrollback"`
-	Status       sql.NullString `json:"status"`
-	StartedAt    sql.NullInt64  `json:"started_at"`
-	LastActiveAt sql.NullInt64  `json:"last_active_at"`
-	EndedAt      sql.NullInt64  `json:"ended_at"`
-	SessionID    sql.NullString `json:"session_id"`
-	ProjectID    sql.NullString `json:"project_id"`
+	PaneID          string         `json:"pane_id"`
+	WorktreeID      sql.NullString `json:"worktree_id"`
+	Shell           sql.NullString `json:"shell"`
+	Cwd             sql.NullString `json:"cwd"`
+	Env             sql.NullString `json:"env"`
+	Cols            sql.NullInt64  `json:"cols"`
+	Rows            sql.NullInt64  `json:"rows"`
+	Scrollback      sql.NullString `json:"scrollback"`
+	Status          sql.NullString `json:"status"`
+	StartedAt       sql.NullInt64  `json:"started_at"`
+	LastActiveAt    sql.NullInt64  `json:"last_active_at"`
+	EndedAt         sql.NullInt64  `json:"ended_at"`
+	SessionID       sql.NullString `json:"session_id"`
+	ProjectID       sql.NullString `json:"project_id"`
+	SerializedState sql.NullString `json:"serialized_state"`
 }
 
 type UserPreference struct {

--- a/v2/internal/db/queries/terminal.sql
+++ b/v2/internal/db/queries/terminal.sql
@@ -8,7 +8,7 @@ SELECT * FROM terminal_sessions WHERE pane_id = ?;
 SELECT * FROM terminal_sessions WHERE status = 'active' ORDER BY started_at DESC;
 
 -- name: CreateTerminalSession :exec
-INSERT INTO terminal_sessions (
+INSERT OR REPLACE INTO terminal_sessions (
     pane_id, worktree_id, project_id, session_id, shell, cwd, env,
     cols, rows, scrollback, status,
     started_at, last_active_at, ended_at

--- a/v2/internal/db/sessions.sql.go
+++ b/v2/internal/db/sessions.sql.go
@@ -186,7 +186,7 @@ func (q *Queries) ForkSession(ctx context.Context, arg ForkSessionParams) error 
 
 const getSession = `-- name: GetSession :one
 
-SELECT id, pid, cwd, repo, name, kind, model, entrypoint, started_at, ended_at, status, task_count, completed_tasks, xp_earned, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, estimated_cost_micros, message_count, tool_use_count, first_prompt, tool_breakdown, last_input_tokens, context_used_pct, date, summary, outcome, files_touched, git_commits, git_lines_added, git_lines_removed, branch, pr_url, pr_status, provider, session_goal, session_type, tool_summary, keywords, parent_session_id FROM sessions WHERE id = ?
+SELECT id, pid, cwd, repo, name, kind, model, entrypoint, started_at, ended_at, status, task_count, completed_tasks, xp_earned, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, estimated_cost_micros, message_count, tool_use_count, first_prompt, tool_breakdown, last_input_tokens, context_used_pct, date, summary, outcome, files_touched, git_commits, git_lines_added, git_lines_removed, branch, pr_url, pr_status, provider, session_goal, session_type, tool_summary, keywords, parent_session_id, session_profile FROM sessions WHERE id = ?
 `
 
 // sessions.sql - CRUD operations for sessions table
@@ -236,12 +236,13 @@ func (q *Queries) GetSession(ctx context.Context, id string) (Session, error) {
 		&i.ToolSummary,
 		&i.Keywords,
 		&i.ParentSessionID,
+		&i.SessionProfile,
 	)
 	return i, err
 }
 
 const listActiveSessions = `-- name: ListActiveSessions :many
-SELECT id, pid, cwd, repo, name, kind, model, entrypoint, started_at, ended_at, status, task_count, completed_tasks, xp_earned, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, estimated_cost_micros, message_count, tool_use_count, first_prompt, tool_breakdown, last_input_tokens, context_used_pct, date, summary, outcome, files_touched, git_commits, git_lines_added, git_lines_removed, branch, pr_url, pr_status, provider, session_goal, session_type, tool_summary, keywords, parent_session_id FROM sessions WHERE status = 'active' ORDER BY started_at DESC
+SELECT id, pid, cwd, repo, name, kind, model, entrypoint, started_at, ended_at, status, task_count, completed_tasks, xp_earned, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, estimated_cost_micros, message_count, tool_use_count, first_prompt, tool_breakdown, last_input_tokens, context_used_pct, date, summary, outcome, files_touched, git_commits, git_lines_added, git_lines_removed, branch, pr_url, pr_status, provider, session_goal, session_type, tool_summary, keywords, parent_session_id, session_profile FROM sessions WHERE status = 'active' ORDER BY started_at DESC
 `
 
 func (q *Queries) ListActiveSessions(ctx context.Context) ([]Session, error) {
@@ -295,6 +296,7 @@ func (q *Queries) ListActiveSessions(ctx context.Context) ([]Session, error) {
 			&i.ToolSummary,
 			&i.Keywords,
 			&i.ParentSessionID,
+			&i.SessionProfile,
 		); err != nil {
 			return nil, err
 		}
@@ -310,7 +312,7 @@ func (q *Queries) ListActiveSessions(ctx context.Context) ([]Session, error) {
 }
 
 const listSessionForks = `-- name: ListSessionForks :many
-SELECT id, pid, cwd, repo, name, kind, model, entrypoint, started_at, ended_at, status, task_count, completed_tasks, xp_earned, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, estimated_cost_micros, message_count, tool_use_count, first_prompt, tool_breakdown, last_input_tokens, context_used_pct, date, summary, outcome, files_touched, git_commits, git_lines_added, git_lines_removed, branch, pr_url, pr_status, provider, session_goal, session_type, tool_summary, keywords, parent_session_id FROM sessions WHERE parent_session_id = ? ORDER BY started_at DESC
+SELECT id, pid, cwd, repo, name, kind, model, entrypoint, started_at, ended_at, status, task_count, completed_tasks, xp_earned, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, estimated_cost_micros, message_count, tool_use_count, first_prompt, tool_breakdown, last_input_tokens, context_used_pct, date, summary, outcome, files_touched, git_commits, git_lines_added, git_lines_removed, branch, pr_url, pr_status, provider, session_goal, session_type, tool_summary, keywords, parent_session_id, session_profile FROM sessions WHERE parent_session_id = ? ORDER BY started_at DESC
 `
 
 // Returns all sessions whose parent_session_id matches the given session.
@@ -365,6 +367,7 @@ func (q *Queries) ListSessionForks(ctx context.Context, parentSessionID sql.Null
 			&i.ToolSummary,
 			&i.Keywords,
 			&i.ParentSessionID,
+			&i.SessionProfile,
 		); err != nil {
 			return nil, err
 		}
@@ -380,7 +383,7 @@ func (q *Queries) ListSessionForks(ctx context.Context, parentSessionID sql.Null
 }
 
 const listSessions = `-- name: ListSessions :many
-SELECT id, pid, cwd, repo, name, kind, model, entrypoint, started_at, ended_at, status, task_count, completed_tasks, xp_earned, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, estimated_cost_micros, message_count, tool_use_count, first_prompt, tool_breakdown, last_input_tokens, context_used_pct, date, summary, outcome, files_touched, git_commits, git_lines_added, git_lines_removed, branch, pr_url, pr_status, provider, session_goal, session_type, tool_summary, keywords, parent_session_id FROM sessions ORDER BY started_at DESC
+SELECT id, pid, cwd, repo, name, kind, model, entrypoint, started_at, ended_at, status, task_count, completed_tasks, xp_earned, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, estimated_cost_micros, message_count, tool_use_count, first_prompt, tool_breakdown, last_input_tokens, context_used_pct, date, summary, outcome, files_touched, git_commits, git_lines_added, git_lines_removed, branch, pr_url, pr_status, provider, session_goal, session_type, tool_summary, keywords, parent_session_id, session_profile FROM sessions ORDER BY started_at DESC
 `
 
 func (q *Queries) ListSessions(ctx context.Context) ([]Session, error) {
@@ -434,6 +437,7 @@ func (q *Queries) ListSessions(ctx context.Context) ([]Session, error) {
 			&i.ToolSummary,
 			&i.Keywords,
 			&i.ParentSessionID,
+			&i.SessionProfile,
 		); err != nil {
 			return nil, err
 		}
@@ -449,7 +453,7 @@ func (q *Queries) ListSessions(ctx context.Context) ([]Session, error) {
 }
 
 const listSessionsByProvider = `-- name: ListSessionsByProvider :many
-SELECT id, pid, cwd, repo, name, kind, model, entrypoint, started_at, ended_at, status, task_count, completed_tasks, xp_earned, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, estimated_cost_micros, message_count, tool_use_count, first_prompt, tool_breakdown, last_input_tokens, context_used_pct, date, summary, outcome, files_touched, git_commits, git_lines_added, git_lines_removed, branch, pr_url, pr_status, provider, session_goal, session_type, tool_summary, keywords, parent_session_id FROM sessions WHERE provider = ? ORDER BY started_at DESC
+SELECT id, pid, cwd, repo, name, kind, model, entrypoint, started_at, ended_at, status, task_count, completed_tasks, xp_earned, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, estimated_cost_micros, message_count, tool_use_count, first_prompt, tool_breakdown, last_input_tokens, context_used_pct, date, summary, outcome, files_touched, git_commits, git_lines_added, git_lines_removed, branch, pr_url, pr_status, provider, session_goal, session_type, tool_summary, keywords, parent_session_id, session_profile FROM sessions WHERE provider = ? ORDER BY started_at DESC
 `
 
 func (q *Queries) ListSessionsByProvider(ctx context.Context, provider string) ([]Session, error) {
@@ -503,6 +507,7 @@ func (q *Queries) ListSessionsByProvider(ctx context.Context, provider string) (
 			&i.ToolSummary,
 			&i.Keywords,
 			&i.ParentSessionID,
+			&i.SessionProfile,
 		); err != nil {
 			return nil, err
 		}
@@ -518,7 +523,7 @@ func (q *Queries) ListSessionsByProvider(ctx context.Context, provider string) (
 }
 
 const listSessionsByStatus = `-- name: ListSessionsByStatus :many
-SELECT id, pid, cwd, repo, name, kind, model, entrypoint, started_at, ended_at, status, task_count, completed_tasks, xp_earned, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, estimated_cost_micros, message_count, tool_use_count, first_prompt, tool_breakdown, last_input_tokens, context_used_pct, date, summary, outcome, files_touched, git_commits, git_lines_added, git_lines_removed, branch, pr_url, pr_status, provider, session_goal, session_type, tool_summary, keywords, parent_session_id FROM sessions WHERE status = ? ORDER BY started_at DESC
+SELECT id, pid, cwd, repo, name, kind, model, entrypoint, started_at, ended_at, status, task_count, completed_tasks, xp_earned, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, estimated_cost_micros, message_count, tool_use_count, first_prompt, tool_breakdown, last_input_tokens, context_used_pct, date, summary, outcome, files_touched, git_commits, git_lines_added, git_lines_removed, branch, pr_url, pr_status, provider, session_goal, session_type, tool_summary, keywords, parent_session_id, session_profile FROM sessions WHERE status = ? ORDER BY started_at DESC
 `
 
 func (q *Queries) ListSessionsByStatus(ctx context.Context, status sql.NullString) ([]Session, error) {
@@ -572,10 +577,38 @@ func (q *Queries) ListSessionsByStatus(ctx context.Context, status sql.NullStrin
 			&i.ToolSummary,
 			&i.Keywords,
 			&i.ParentSessionID,
+			&i.SessionProfile,
 		); err != nil {
 			return nil, err
 		}
 		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listUnnamedSessions = `-- name: ListUnnamedSessions :many
+SELECT id FROM sessions WHERE name IS NULL OR name = ''
+`
+
+func (q *Queries) ListUnnamedSessions(ctx context.Context) ([]string, error) {
+	rows, err := q.db.QueryContext(ctx, listUnnamedSessions)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []string{}
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
 	}
 	if err := rows.Close(); err != nil {
 		return nil, err
@@ -720,6 +753,20 @@ func (q *Queries) UpdateSessionEnrichment(ctx context.Context, arg UpdateSession
 	return err
 }
 
+const updateSessionName = `-- name: UpdateSessionName :exec
+UPDATE sessions SET name = ? WHERE id = ?
+`
+
+type UpdateSessionNameParams struct {
+	Name sql.NullString `json:"name"`
+	ID   string         `json:"id"`
+}
+
+func (q *Queries) UpdateSessionName(ctx context.Context, arg UpdateSessionNameParams) error {
+	_, err := q.db.ExecContext(ctx, updateSessionName, arg.Name, arg.ID)
+	return err
+}
+
 const updateSessionStatus = `-- name: UpdateSessionStatus :exec
 UPDATE sessions SET
     status = ?,
@@ -779,42 +826,4 @@ func (q *Queries) UpdateSessionTokens(ctx context.Context, arg UpdateSessionToke
 		arg.ID,
 	)
 	return err
-}
-
-const updateSessionName = `-- name: UpdateSessionName :exec
-UPDATE sessions SET name = ? WHERE id = ?
-`
-
-type UpdateSessionNameParams struct {
-	Name sql.NullString `json:"name"`
-	ID   string         `json:"id"`
-}
-
-func (q *Queries) UpdateSessionName(ctx context.Context, arg UpdateSessionNameParams) error {
-	_, err := q.db.ExecContext(ctx, updateSessionName, arg.Name, arg.ID)
-	return err
-}
-
-const listUnnamedSessions = `-- name: ListUnnamedSessions :many
-SELECT id FROM sessions WHERE name IS NULL OR name = ''
-`
-
-func (q *Queries) ListUnnamedSessions(ctx context.Context) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, listUnnamedSessions)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []string
-	for rows.Next() {
-		var id string
-		if err := rows.Scan(&id); err != nil {
-			return nil, err
-		}
-		items = append(items, id)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
 }

--- a/v2/internal/db/terminal.sql.go
+++ b/v2/internal/db/terminal.sql.go
@@ -11,7 +11,7 @@ import (
 )
 
 const createTerminalSession = `-- name: CreateTerminalSession :exec
-INSERT INTO terminal_sessions (
+INSERT OR REPLACE INTO terminal_sessions (
     pane_id, worktree_id, project_id, session_id, shell, cwd, env,
     cols, rows, scrollback, status,
     started_at, last_active_at, ended_at
@@ -121,9 +121,20 @@ func (q *Queries) GetTerminalForRestore(ctx context.Context, paneID string) (Get
 	return i, err
 }
 
+const getTerminalSerializedState = `-- name: GetTerminalSerializedState :one
+SELECT serialized_state FROM terminal_sessions WHERE pane_id = ?
+`
+
+func (q *Queries) GetTerminalSerializedState(ctx context.Context, paneID string) (sql.NullString, error) {
+	row := q.db.QueryRowContext(ctx, getTerminalSerializedState, paneID)
+	var serialized_state sql.NullString
+	err := row.Scan(&serialized_state)
+	return serialized_state, err
+}
+
 const getTerminalSession = `-- name: GetTerminalSession :one
 
-SELECT pane_id, worktree_id, shell, cwd, env, cols, "rows", scrollback, status, started_at, last_active_at, ended_at, session_id, project_id FROM terminal_sessions WHERE pane_id = ?
+SELECT pane_id, worktree_id, shell, cwd, env, cols, "rows", scrollback, status, started_at, last_active_at, ended_at, session_id, project_id, serialized_state FROM terminal_sessions WHERE pane_id = ?
 `
 
 // terminal.sql - CRUD operations for terminal_sessions table
@@ -146,12 +157,13 @@ func (q *Queries) GetTerminalSession(ctx context.Context, paneID string) (Termin
 		&i.EndedAt,
 		&i.SessionID,
 		&i.ProjectID,
+		&i.SerializedState,
 	)
 	return i, err
 }
 
 const getTerminalsBySessionId = `-- name: GetTerminalsBySessionId :many
-SELECT pane_id, worktree_id, shell, cwd, env, cols, "rows", scrollback, status, started_at, last_active_at, ended_at, session_id, project_id FROM terminal_sessions WHERE session_id = ?
+SELECT pane_id, worktree_id, shell, cwd, env, cols, "rows", scrollback, status, started_at, last_active_at, ended_at, session_id, project_id, serialized_state FROM terminal_sessions WHERE session_id = ?
 `
 
 func (q *Queries) GetTerminalsBySessionId(ctx context.Context, sessionID sql.NullString) ([]TerminalSession, error) {
@@ -178,6 +190,7 @@ func (q *Queries) GetTerminalsBySessionId(ctx context.Context, sessionID sql.Nul
 			&i.EndedAt,
 			&i.SessionID,
 			&i.ProjectID,
+			&i.SerializedState,
 		); err != nil {
 			return nil, err
 		}
@@ -206,7 +219,7 @@ func (q *Queries) LinkTerminalToSession(ctx context.Context, arg LinkTerminalToS
 }
 
 const listActiveTerminals = `-- name: ListActiveTerminals :many
-SELECT pane_id, worktree_id, shell, cwd, env, cols, "rows", scrollback, status, started_at, last_active_at, ended_at, session_id, project_id FROM terminal_sessions WHERE status = 'active' ORDER BY started_at DESC
+SELECT pane_id, worktree_id, shell, cwd, env, cols, "rows", scrollback, status, started_at, last_active_at, ended_at, session_id, project_id, serialized_state FROM terminal_sessions WHERE status = 'active' ORDER BY started_at DESC
 `
 
 func (q *Queries) ListActiveTerminals(ctx context.Context) ([]TerminalSession, error) {
@@ -233,6 +246,7 @@ func (q *Queries) ListActiveTerminals(ctx context.Context) ([]TerminalSession, e
 			&i.EndedAt,
 			&i.SessionID,
 			&i.ProjectID,
+			&i.SerializedState,
 		); err != nil {
 			return nil, err
 		}
@@ -248,7 +262,7 @@ func (q *Queries) ListActiveTerminals(ctx context.Context) ([]TerminalSession, e
 }
 
 const listRecentlyEndedTerminals = `-- name: ListRecentlyEndedTerminals :many
-SELECT pane_id, worktree_id, shell, cwd, env, cols, "rows", scrollback, status, started_at, last_active_at, ended_at, session_id, project_id FROM terminal_sessions WHERE status = 'ended' AND ended_at >= ? ORDER BY ended_at DESC
+SELECT pane_id, worktree_id, shell, cwd, env, cols, "rows", scrollback, status, started_at, last_active_at, ended_at, session_id, project_id, serialized_state FROM terminal_sessions WHERE status = 'ended' AND ended_at >= ? ORDER BY ended_at DESC
 `
 
 func (q *Queries) ListRecentlyEndedTerminals(ctx context.Context, endedAt sql.NullInt64) ([]TerminalSession, error) {
@@ -275,6 +289,7 @@ func (q *Queries) ListRecentlyEndedTerminals(ctx context.Context, endedAt sql.Nu
 			&i.EndedAt,
 			&i.SessionID,
 			&i.ProjectID,
+			&i.SerializedState,
 		); err != nil {
 			return nil, err
 		}
@@ -290,7 +305,7 @@ func (q *Queries) ListRecentlyEndedTerminals(ctx context.Context, endedAt sql.Nu
 }
 
 const listTerminalsByProject = `-- name: ListTerminalsByProject :many
-SELECT pane_id, worktree_id, shell, cwd, env, cols, "rows", scrollback, status, started_at, last_active_at, ended_at, session_id, project_id FROM terminal_sessions WHERE project_id = ? AND status = 'active' ORDER BY started_at DESC
+SELECT pane_id, worktree_id, shell, cwd, env, cols, "rows", scrollback, status, started_at, last_active_at, ended_at, session_id, project_id, serialized_state FROM terminal_sessions WHERE project_id = ? AND status = 'active' ORDER BY started_at DESC
 `
 
 func (q *Queries) ListTerminalsByProject(ctx context.Context, projectID sql.NullString) ([]TerminalSession, error) {
@@ -317,6 +332,7 @@ func (q *Queries) ListTerminalsByProject(ctx context.Context, projectID sql.Null
 			&i.EndedAt,
 			&i.SessionID,
 			&i.ProjectID,
+			&i.SerializedState,
 		); err != nil {
 			return nil, err
 		}
@@ -332,7 +348,7 @@ func (q *Queries) ListTerminalsByProject(ctx context.Context, projectID sql.Null
 }
 
 const listTerminalsByWorktree = `-- name: ListTerminalsByWorktree :many
-SELECT pane_id, worktree_id, shell, cwd, env, cols, "rows", scrollback, status, started_at, last_active_at, ended_at, session_id, project_id FROM terminal_sessions WHERE worktree_id = ? AND status = 'active' ORDER BY started_at DESC
+SELECT pane_id, worktree_id, shell, cwd, env, cols, "rows", scrollback, status, started_at, last_active_at, ended_at, session_id, project_id, serialized_state FROM terminal_sessions WHERE worktree_id = ? AND status = 'active' ORDER BY started_at DESC
 `
 
 func (q *Queries) ListTerminalsByWorktree(ctx context.Context, worktreeID sql.NullString) ([]TerminalSession, error) {
@@ -359,6 +375,7 @@ func (q *Queries) ListTerminalsByWorktree(ctx context.Context, worktreeID sql.Nu
 			&i.EndedAt,
 			&i.SessionID,
 			&i.ProjectID,
+			&i.SerializedState,
 		); err != nil {
 			return nil, err
 		}
@@ -374,7 +391,7 @@ func (q *Queries) ListTerminalsByWorktree(ctx context.Context, worktreeID sql.Nu
 }
 
 const listUnlinkedActiveTerminals = `-- name: ListUnlinkedActiveTerminals :many
-SELECT pane_id, worktree_id, shell, cwd, env, cols, "rows", scrollback, status, started_at, last_active_at, ended_at, session_id, project_id FROM terminal_sessions WHERE status = 'active' AND session_id IS NULL
+SELECT pane_id, worktree_id, shell, cwd, env, cols, "rows", scrollback, status, started_at, last_active_at, ended_at, session_id, project_id, serialized_state FROM terminal_sessions WHERE status = 'active' AND session_id IS NULL
 `
 
 func (q *Queries) ListUnlinkedActiveTerminals(ctx context.Context) ([]TerminalSession, error) {
@@ -401,6 +418,7 @@ func (q *Queries) ListUnlinkedActiveTerminals(ctx context.Context) ([]TerminalSe
 			&i.EndedAt,
 			&i.SessionID,
 			&i.ProjectID,
+			&i.SerializedState,
 		); err != nil {
 			return nil, err
 		}
@@ -416,7 +434,7 @@ func (q *Queries) ListUnlinkedActiveTerminals(ctx context.Context) ([]TerminalSe
 }
 
 const listUnlinkedActiveTerminalsByWorktree = `-- name: ListUnlinkedActiveTerminalsByWorktree :many
-SELECT pane_id, worktree_id, shell, cwd, env, cols, "rows", scrollback, status, started_at, last_active_at, ended_at, session_id, project_id FROM terminal_sessions WHERE worktree_id = ? AND status = 'active' AND session_id IS NULL ORDER BY started_at DESC
+SELECT pane_id, worktree_id, shell, cwd, env, cols, "rows", scrollback, status, started_at, last_active_at, ended_at, session_id, project_id, serialized_state FROM terminal_sessions WHERE worktree_id = ? AND status = 'active' AND session_id IS NULL ORDER BY started_at DESC
 `
 
 func (q *Queries) ListUnlinkedActiveTerminalsByWorktree(ctx context.Context, worktreeID sql.NullString) ([]TerminalSession, error) {
@@ -443,6 +461,7 @@ func (q *Queries) ListUnlinkedActiveTerminalsByWorktree(ctx context.Context, wor
 			&i.EndedAt,
 			&i.SessionID,
 			&i.ProjectID,
+			&i.SerializedState,
 		); err != nil {
 			return nil, err
 		}
@@ -544,15 +563,4 @@ type UpdateTerminalSerializedStateParams struct {
 func (q *Queries) UpdateTerminalSerializedState(ctx context.Context, arg UpdateTerminalSerializedStateParams) error {
 	_, err := q.db.ExecContext(ctx, updateTerminalSerializedState, arg.SerializedState, arg.LastActiveAt, arg.PaneID)
 	return err
-}
-
-const getTerminalSerializedState = `-- name: GetTerminalSerializedState :one
-SELECT serialized_state FROM terminal_sessions WHERE pane_id = ?
-`
-
-func (q *Queries) GetTerminalSerializedState(ctx context.Context, paneID string) (sql.NullString, error) {
-	row := q.db.QueryRowContext(ctx, getTerminalSerializedState, paneID)
-	var serialized_state sql.NullString
-	err := row.Scan(&serialized_state)
-	return serialized_state, err
 }


### PR DESCRIPTION
## Summary
- Changed `CreateTerminalSession` from `INSERT` to `INSERT OR REPLACE` to handle pane remounts
- Eliminates `UNIQUE constraint failed: terminal_sessions.pane_id (1555)` errors in logs
- Includes sqlc regeneration against current schema

## Test plan
- [ ] Open/close/reopen terminal panes — no constraint errors in logs
- [ ] Terminal sessions persist correctly in DB

PR Generated with AI

Co-Authored-By: AI