### PR TITLE
fix: run orchestrator.Process in goroutine so 2s timeout actually fires

### DIFF
--- a/v2/internal/composer/bindings.go
+++ b/v2/internal/composer/bindings.go
@@ -546,11 +546,30 @@ func (b *Bindings) tryEnrichAndEmitStrategy(session *Session, req SendRequest) j
 			}
 		}
 
-		result, err := orchestrator.Process(enrichCtx, turnDeps, orchestrator.ProcessInput{
-			Goal:        userText,
-			CWD:         session.CWD,
-			ActiveFiles: activeFiles,
-		})
+		type orchResult struct {
+			result *orchestrator.ProcessResult
+			err    error
+		}
+		orchCh := make(chan orchResult, 1)
+		go func() {
+			r, e := orchestrator.Process(enrichCtx, turnDeps, orchestrator.ProcessInput{
+				Goal:        userText,
+				CWD:         session.CWD,
+				ActiveFiles: activeFiles,
+			})
+			orchCh <- orchResult{r, e}
+		}()
+
+		var result *orchestrator.ProcessResult
+		var err error
+		select {
+		case or := <-orchCh:
+			result, err = or.result, or.err
+		case <-enrichCtx.Done():
+			log.Warn("composer: orchestrator timed out, sending unenriched prompt")
+			return nil
+		}
+
 		if err == nil && result != nil && result.Strategy.Name != "" {
 			log.Info("composer: orchestrator result", "strategy", result.Strategy.Name, "confidence", result.Confidence, "complexity", result.TaskContext.Complexity, "risk", result.TaskContext.Risk, "blast_radius", result.Context.BlastRadius)
 


### PR DESCRIPTION
## Summary
- Wrapped `orchestrator.Process` in a goroutine with channel-based select against `enrichCtx.Done()`
- The 2s enrichment timeout now actually fires — previously `orchestrator.Process` ignored context cancellation and blocked until completion (5-15s on cold DB)
- When timeout fires, returns nil immediately so raw prompt goes to Claude without waiting

## Root cause
`orchestrator.Process` never checks `ctx.Done()` — it runs all DB queries, vector store lookups, and strategy scoring synchronously. The `context.WithTimeout(b.ctx, 2*time.Second)` only cancelled the context but didn't interrupt the blocking function. In production (cold filesystem cache), these queries take >2s, causing the composer to appear stuck.

In dev mode, the SQLite cache is warm from recent runs, so queries complete <2s and the timeout never fires — explaining why dev was fast but production was slow.

## Test plan
- [ ] Production build: composer responds within ~2s even on cold start
- [ ] Strategy chip appears when orchestrator completes fast (dev mode)
- [ ] No strategy chip when orchestrator times out (graceful degradation)
- [ ] No goroutine leaks — orphaned orchestrator.Process runs to completion in background

PR Generated with AI

Co-Authored-By: AI