### PR TITLE
fix: use DetectClaudeBinary in V2 session spawn for production PATH

### DIFF
--- a/v2/internal/composer/session.go
+++ b/v2/internal/composer/session.go
@@ -237,7 +237,12 @@ func defaultCmdFactory(ctx context.Context, cwd string, opts SessionOptions) *ex
 		args = append(args, "--setting-sources", "")
 	}
 
-	cmd := exec.CommandContext(ctx, "claude", args...)
+	bin, err := DetectClaudeBinary()
+	if err != nil {
+		log.Warn("composer: claude CLI not found, falling back to bare 'claude'", "err", err)
+		bin = "claude"
+	}
+	cmd := exec.CommandContext(ctx, bin, args...)
 	cmd.Dir = cwd
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	return cmd


### PR DESCRIPTION
## Summary
- V2 `defaultCmdFactory` used bare `"claude"` in `exec.CommandContext` — invisible in production .app PATH
- Now uses `DetectClaudeBinary()` to probe `~/.local/bin`, `~/.claude/bin`, `/opt/homebrew/bin` fallbacks
- This is the **actual root cause** of production composer being stuck — the CLI binary was never found

## Root cause
macOS `.app` bundles get minimal PATH (`/usr/bin:/bin:/usr/sbin:/sbin`). The `claude` CLI at `~/.local/bin/claude` isn't on that PATH. `exec.CommandContext(ctx, "claude", ...)` silently failed to find the binary, and the session appeared stuck on "thinking..." because no subprocess was running.

Dev mode works because `wails dev` inherits the full shell PATH.

## Test plan
- [ ] Production .app: composer sends message and gets response
- [ ] Strategy chip appears when orchestrator completes
- [ ] Dev mode unchanged
- [ ] Falls back to bare "claude" if DetectClaudeBinary fails (log warning)

PR Generated with AI

Co-Authored-By: AI