### PR TITLE
fix: augment PATH for production .app subprocess environment

### DIFF
--- a/v2/internal/composer/auth.go
+++ b/v2/internal/composer/auth.go
@@ -50,13 +50,22 @@ func NewAuthCoordinator(m *Manager) *AuthCoordinator {
 	return &AuthCoordinator{
 		manager: m,
 		ProbeCmd: func(ctx context.Context) *exec.Cmd {
-			// Use `auth status` to check token validity without
-			// hitting the API. Fast (~100ms) and exits 0 when logged in.
-			return exec.CommandContext(ctx, "claude", "auth", "status")
+			bin, err := DetectClaudeBinary()
+			if err != nil {
+				bin = "claude"
+			}
+			cmd := exec.CommandContext(ctx, bin, "auth", "status")
+			cmd.Env = AugmentedEnv()
+			return cmd
 		},
 		RefreshCmd: func(ctx context.Context) *exec.Cmd {
-			// Use `auth login` to re-authenticate when the token is invalid.
-			return exec.CommandContext(ctx, "claude", "auth", "login")
+			bin, err := DetectClaudeBinary()
+			if err != nil {
+				bin = "claude"
+			}
+			cmd := exec.CommandContext(ctx, bin, "auth", "login")
+			cmd.Env = AugmentedEnv()
+			return cmd
 		},
 	}
 }

--- a/v2/internal/composer/cli.go
+++ b/v2/internal/composer/cli.go
@@ -79,6 +79,22 @@ func DetectClaudeBinary() (string, error) {
 	)
 }
 
+// AugmentedEnv returns the current environment with candidatePaths prepended
+// to PATH. Production .app bundles get a minimal PATH from macOS; this
+// ensures the claude subprocess (and its children) can find node, bun, git,
+// and other tools that live in user-local or Homebrew directories.
+func AugmentedEnv() []string {
+	env := os.Environ()
+	extra := strings.Join(candidatePaths, ":")
+	for i, e := range env {
+		if strings.HasPrefix(e, "PATH=") {
+			env[i] = "PATH=" + extra + ":" + e[5:]
+			return env
+		}
+	}
+	return append(env, "PATH="+extra+":/usr/bin:/bin:/usr/sbin:/sbin")
+}
+
 // GetCLIVersion runs `claude --version` and extracts the semver string.
 // It enforces a 2-second timeout to avoid hanging on broken installs.
 func GetCLIVersion(binaryPath string) (string, error) {

--- a/v2/internal/composer/session.go
+++ b/v2/internal/composer/session.go
@@ -244,6 +244,7 @@ func defaultCmdFactory(ctx context.Context, cwd string, opts SessionOptions) *ex
 	}
 	cmd := exec.CommandContext(ctx, bin, args...)
 	cmd.Dir = cwd
+	cmd.Env = AugmentedEnv()
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	return cmd
 }


### PR DESCRIPTION
## Summary
- Add `AugmentedEnv()` to prepend `~/.local/bin`, `~/.claude/bin`, `/opt/homebrew/bin`, `/usr/local/bin` to PATH
- Inject augmented env into `defaultCmdFactory` via `cmd.Env`
- Fix auth coordinator `ProbeCmd`/`RefreshCmd` to use `DetectClaudeBinary` + `AugmentedEnv`

## Root cause
macOS `.app` bundles get minimal PATH. PR #107 fixed finding the `claude` binary itself, but the spawned CLI subprocess still inherited the minimal PATH. When Claude CLI tried to start MCP servers, hooks, or find `node`/`bun`/`git`, those tools were invisible — causing the CLI to hang silently during startup (watchdog killed it after 2 minutes).

## Test plan
- [ ] Production .app: composer responds to messages
- [ ] Auth probe no longer shows "executable file not found in $PATH"
- [ ] MCP servers start correctly in production
- [ ] Dev mode unchanged

PR Generated with AI

Co-Authored-By: AI