### PR TITLE
fix: build universal libghostty for CI release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,11 +85,11 @@ jobs:
         uses: actions/cache@v4
         with:
           path: v2/third_party/ghostty/macos/GhosttyKit.xcframework
-          key: libghostty-${{ env.GHOSTTY_SHA }}
+          key: libghostty-universal-${{ env.GHOSTTY_SHA }}
 
-      - name: Build libghostty
+      - name: Build libghostty (universal)
         if: steps.cache-libghostty.outputs.cache-hit != 'true'
-        run: make libghostty
+        run: make libghostty-universal
 
       - name: Sync version into wails.json + VERSION
         run: |

--- a/v2/Makefile
+++ b/v2/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev build clean test lint sqlc frontend-install frontend-build frontend-typecheck go-build go-test go-lint ci mcp-build mcp-bundle docs-llm release release-build release-sign release-notarize release-zip release-dmg libghostty libghostty-clean perf-bench
+.PHONY: dev build clean test lint sqlc frontend-install frontend-build frontend-typecheck go-build go-test go-lint ci mcp-build mcp-bundle docs-llm release release-build release-sign release-notarize release-zip release-dmg libghostty libghostty-universal libghostty-clean perf-bench
 
 # Build libghostty xcframework for embedding (Metal renderer).
 # Requires: zig@0.15 (brew install zig@0.15) and Xcode Metal Toolchain
@@ -18,6 +18,17 @@ $(LIBGHOSTTY_LIB):
 	cd $(LIBGHOSTTY_DIR) && $(ZIG_BIN) build \
 		--release=fast \
 		-Dxcframework-target=native \
+		-Demit-xcframework=true \
+		-Demit-exe=false \
+		-Demit-macos-app=false \
+		-Demit-docs=false
+
+libghostty-universal:
+	@command -v $(ZIG_BIN) >/dev/null || (echo "zig 0.15 not found: brew install zig@0.15"; exit 1)
+	@xcrun -find metal >/dev/null 2>&1 || (echo "Metal toolchain missing: xcodebuild -downloadComponent MetalToolchain"; exit 1)
+	cd $(LIBGHOSTTY_DIR) && $(ZIG_BIN) build \
+		--release=fast \
+		-Dxcframework-target=universal \
 		-Demit-xcframework=true \
 		-Demit-exe=false \
 		-Demit-macos-app=false \


### PR DESCRIPTION
## Summary
- CI release was failing because `make libghostty` built arm64-only (`-Dxcframework-target=native`) while `make release-zip` targets `darwin/universal`
- Added `libghostty-universal` Makefile target with `-Dxcframework-target=universal`
- Updated CI workflow to use the universal target and busted the cache key

## Test plan
- [ ] Merge triggers release-please, which tags → triggers Release workflow
- [ ] "Build libghostty (universal)" step produces both arm64 + x86_64 objects
- [ ] "Build, sign, notarize, zip" step links successfully for both architectures

PR Generated with AI

Co-Authored-By: AI