### PR TITLE
feat: add type labels to sidebar worktree items

### DIFF
--- a/v2/frontend/src/components/sidebar/WorktreeItem.tsx
+++ b/v2/frontend/src/components/sidebar/WorktreeItem.tsx
@@ -144,6 +144,9 @@ export function WorktreeItem(props: WorktreeItemProps) {
         <span class={styles.branchName}>
           {props.worktree.branch}
         </span>
+        <span class={styles.typeLabel}>
+          {props.worktree.type === 'branch' ? 'branch' : 'worktree'}
+        </span>
         <Show when={dirtyStatus()}>
           {(d) => (
             <span

--- a/v2/frontend/src/styles/sidebar.css.ts
+++ b/v2/frontend/src/styles/sidebar.css.ts
@@ -217,6 +217,18 @@ export const branchName = style({
 // Compact dirty-file badge rendered after the branch name when the worktree
 // has uncommitted changes. Hidden entirely when the working tree is clean
 // (rendered conditionally in WorktreeItem). Format: `±N`.
+export const typeLabel = style({
+  fontSize: '9px',
+  fontFamily: vars.font.mono,
+  fontWeight: 500,
+  color: vars.color.textDisabled,
+  textTransform: 'uppercase',
+  letterSpacing: '0.04em',
+  flexShrink: 0,
+  lineHeight: '14px',
+  userSelect: 'none',
+});
+
 export const dirtyBadge = style({
   fontSize: '10px',
   fontFamily: vars.font.mono,


### PR DESCRIPTION
## Summary
- Adds small uppercase dimmed labels ("BRANCH" / "WORKTREE") to each sidebar worktree row
- Makes it immediately clear which items are projects and which are worktree branches
- New `typeLabel` style in `sidebar.css.ts` — 9px mono, uppercase, `textDisabled` color

## Test plan
- [ ] Open the sidebar with multiple projects expanded
- [ ] Verify each branch row shows "BRANCH" label
- [ ] Verify each worktree row shows "WORKTREE" label
- [ ] Confirm labels don't overlap with dirty badges or session dots
- [ ] Check collapsed projects still look correct (no labels on project headers)

PR Generated with AI

Co-Authored-By: AI