### PR TITLE
feat: show Greptile confidence score on PR cards

### DIFF
--- a/v2/frontend/src/components/panes/WorktreeHome.tsx
+++ b/v2/frontend/src/components/panes/WorktreeHome.tsx
@@ -28,6 +28,36 @@ import type { RepoStatus, PrStatus as PrStatusType, CiRun, CheckAnnotation, Fail
 import * as styles from '@/styles/home.css';
 
 
+function GreptileBadge(props: { score: string }) {
+  const num = () => {
+    const n = parseInt(props.score);
+    return isNaN(n) ? 0 : n;
+  };
+  const color = () => {
+    const n = num();
+    if (n >= 4) return vars.color.success;
+    if (n >= 2) return vars.color.warning;
+    return vars.color.danger;
+  };
+
+  return (
+    <Tip label={`Greptile confidence: ${props.score}`}>
+      <span
+        class={styles.greptileBadge}
+        style={{
+          color: color(),
+          'background-color': `color-mix(in srgb, ${color()} 15%, transparent)`,
+        }}
+      >
+        <svg width="10" height="10" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+          <path d="M8 0L14.928 4v8L8 16 1.072 12V4z"/>
+        </svg>
+        {props.score}
+      </span>
+    </Tip>
+  );
+}
+
 function RecentSessions(props: { repoPath: string | null }) {
   const [recentSessions, setRecentSessions] = createSignal<JournalEntry[]>([]);
 
@@ -830,6 +860,9 @@ export default function WorktreeHome() {
               </div>
 
               {/* Reviewer row + Ship-It action */}
+              <Show when={prStatus()!.greptile_score}>
+                <GreptileBadge score={prStatus()!.greptile_score!} />
+              </Show>
               <ReviewerRow pr={prStatus()!} />
               <ShipItButton pr={prStatus()!} cfg={repoMergeCfg()} />
 
@@ -1061,6 +1094,9 @@ function OpenPrCard(props: {
       </Show>
 
       <div class={styles.prCardActions}>
+        <Show when={pr.greptile_score}>
+          <GreptileBadge score={pr.greptile_score!} />
+        </Show>
         <Show when={pr.review_decision === 'APPROVED'}>
           <span class={styles.prApprovedBadge}>
             <CheckCircle size={10} />

--- a/v2/frontend/src/core/types/index.ts
+++ b/v2/frontend/src/core/types/index.ts
@@ -237,6 +237,7 @@ export interface PrStatus {
   changes_requested_by?: Reviewer[];
   awaiting_review_from?: Reviewer[];
   labels?: Label[];
+  greptile_score?: string;
 }
 
 export interface Label {

--- a/v2/frontend/src/styles/home.css.ts
+++ b/v2/frontend/src/styles/home.css.ts
@@ -1989,6 +1989,20 @@ export const prApprovedBadge = style({
   color: vars.color.success,
 });
 
+export const greptileBadge = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '3px',
+  fontSize: '0.55rem',
+  fontWeight: 700,
+  fontFamily: vars.font.mono,
+  padding: '1px 6px',
+  borderRadius: '3px',
+  flexShrink: 0,
+  letterSpacing: '0.03em',
+  lineHeight: '14px',
+});
+
 export const shipItMergedPill = style({
   display: 'inline-flex',
   alignItems: 'center',

--- a/v2/internal/git/github.go
+++ b/v2/internal/git/github.go
@@ -191,6 +191,9 @@ func GetPrStatus(ctx context.Context, repoPath, branch string) (*PrStatus, error
 		pr.MergeQueueEta = eta
 	}
 
+	// Best-effort: fetch Greptile confidence score from PR comments.
+	pr.GreptileScore = fetchGreptileScore(ctx, repoPath, raw.Number)
+
 	log.Info("git/GetPrStatus: success",
 		"number", pr.Number, "state", pr.State, "checks", pr.ChecksTotal,
 		"mergeState", pr.MergeStateStatus, "reviewDecision", pr.ReviewDecision)
@@ -343,8 +346,76 @@ func ListOpenPrsForBase(ctx context.Context, repoPath, baseBranch string, limit 
 			Labels:             mapLabels(r.Labels),
 		})
 	}
+
+	// Best-effort: fetch Greptile scores in parallel.
+	if len(prs) > 0 {
+		type scoreResult struct {
+			idx   int
+			score string
+		}
+		ch := make(chan scoreResult, len(prs))
+		for i, p := range prs {
+			go func(idx, num int) {
+				ch <- scoreResult{idx, fetchGreptileScore(ctx, repoPath, num)}
+			}(i, p.Number)
+		}
+		for range prs {
+			r := <-ch
+			prs[r.idx].GreptileScore = r.score
+		}
+	}
+
 	log.Info("git/ListOpenPrsForBase: success", "count", len(prs))
 	return prs, nil
+}
+
+// fetchGreptileScore fetches the Greptile confidence score for a PR from its comments.
+// Returns "X/5" or "" if no Greptile review found.
+func fetchGreptileScore(ctx context.Context, repoPath string, prNumber int) string {
+	owner, repo, err := resolveOwnerRepo(ctx, repoPath)
+	if err != nil {
+		return ""
+	}
+
+	data, err := ghAPIGet(ctx, owner, repo, fmt.Sprintf("issues/%d/comments?per_page=50", prNumber))
+	if err != nil {
+		return ""
+	}
+
+	var comments []struct {
+		User struct {
+			Login string `json:"login"`
+		} `json:"user"`
+		Body string `json:"body"`
+	}
+	if err := json.Unmarshal(data, &comments); err != nil {
+		return ""
+	}
+
+	for _, c := range comments {
+		if !strings.Contains(strings.ToLower(c.User.Login), "greptile") {
+			continue
+		}
+		// Parse "Confidence Score: X/5" from body
+		idx := strings.Index(c.Body, "Confidence Score:")
+		if idx == -1 {
+			continue
+		}
+		rest := c.Body[idx+len("Confidence Score:"):]
+		rest = strings.TrimSpace(rest)
+		// Extract "X/5" pattern
+		for i, ch := range rest {
+			if ch == '\n' || ch == '\r' || ch == '<' || i > 10 {
+				rest = rest[:i]
+				break
+			}
+		}
+		rest = strings.TrimSpace(rest)
+		if rest != "" {
+			return rest
+		}
+	}
+	return ""
 }
 
 // ghCheckJSON is the raw JSON shape returned by `gh pr checks`.

--- a/v2/internal/git/github_types.go
+++ b/v2/internal/git/github_types.go
@@ -46,6 +46,7 @@ type PrStatus struct {
 	ChangesRequestedBy []Reviewer `json:"changes_requested_by"`
 	AwaitingReviewFrom []Reviewer `json:"awaiting_review_from"`
 	Labels             []Label    `json:"labels"`
+	GreptileScore      string     `json:"greptile_score"` // "3/5", "" if no Greptile review
 }
 
 // RepoMergeConfig holds repo-level merge settings used to drive the Ship-It UI.


### PR DESCRIPTION
## Summary
- Fetches Greptile bot comments from GitHub PR comments API and parses "Confidence Score: X/5"
- Displays color-coded badge (green 4-5, amber 2-3, red 0-1) in PR card actions row alongside Approved/Review badges
- Backend: `fetchGreptileScore()` uses `ghAPIGet` for single PR and parallel goroutines for PR list view
- Frontend: `GreptileBadge` component with hexagon icon + score in both OpenPrCard and feature branch PR card

## Test plan
- [ ] Open a worktree on default branch — verify Greptile scores appear on open PR cards that have Greptile reviews
- [ ] Open a worktree on feature branch with a PR — verify Greptile badge shows in actions row
- [ ] Verify PRs without Greptile review show no badge
- [ ] Verify score displays clean "X/5" without HTML artifacts

PR Generated with AI

Co-Authored-By: AI