### PR TITLE
feat: notes drawer with TipTap WYSIWYG and Cmd+Shift+N

### DIFF
--- a/v2/frontend/src/app.tsx
+++ b/v2/frontend/src/app.tsx
@@ -43,6 +43,7 @@ import { ShortcutSheet } from './shared/ShortcutSheet/ShortcutSheet';
 import { WorktreeSwitcher } from './shared/WorktreeSwitcher';
 import { RecipePicker } from './shared/RecipePicker';
 import { AgentsOverlay } from './shared/AgentsOverlay';
+import { StickyNotesOverlay } from './shared/StickyNotesOverlay';
 import { McpManagerDialog } from './shared/McpManagerDialog';
 import { PromptComposer } from './shared/PromptComposer';
 import { composerVisible, closeComposer } from './core/signals/composer';
@@ -267,6 +268,7 @@ export function App() {
   return (
     <div class={shellClass()}>
       <ToastRegion />
+      <StickyNotesOverlay />
       <SettingsDialog />
       <AICommandCenter />
       <QuickOpen />

--- a/v2/frontend/src/core/bindings/index.ts
+++ b/v2/frontend/src/core/bindings/index.ts
@@ -65,4 +65,4 @@ export { listMCPServers, toggleMCPServer, registerPhantomMCP } from './mcp';
 export type { MCPServer } from './mcp';
 export { searchFileContents } from './search';
 export type { SearchResult } from './search';
-export { listProjectNotes, createProjectNote, updateProjectNote, deleteProjectNote } from './notes';
+export { listProjectNotes, createProjectNote, updateProjectNote, deleteProjectNote, updateNotePosition } from './notes';

--- a/v2/frontend/src/core/bindings/notes.ts
+++ b/v2/frontend/src/core/bindings/notes.ts
@@ -40,3 +40,12 @@ export async function deleteProjectNote(id: string): Promise<boolean> {
     return false;
   }
 }
+
+export async function updateNotePosition(id: string, posX: number, posY: number): Promise<boolean> {
+  try {
+    await App()?.UpdateNotePosition(id, Math.round(posX), Math.round(posY));
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/v2/frontend/src/core/keyboard.ts
+++ b/v2/frontend/src/core/keyboard.ts
@@ -15,6 +15,7 @@ import { toggleCommandPalette } from './signals/command-palette';
 import { openRecipePicker } from './signals/recipes';
 import { toggleShortcutSheet } from './signals/shortcut-sheet';
 import { toggleAgentsOverlay } from './signals/agents-overlay';
+import { toggleStickyOverlay } from './signals/notes';
 
 import { switcherVisible, openSwitcher, closeSwitcher, advanceSwitcher, commitSwitcher } from './signals/worktree-switcher';
 import { goBack, goForward } from './signals/navigation';
@@ -84,6 +85,13 @@ export function registerKeyboardShortcuts(): () => void {
     if (meta && e.key === '2') {
       e.preventDefault();
       setActiveTopTab('worktree');
+      return;
+    }
+
+    // Cmd+Shift+N: Toggle sticky notes overlay
+    if (meta && e.shiftKey && (e.key === 'N' || e.key === 'n')) {
+      e.preventDefault();
+      toggleStickyOverlay();
       return;
     }
 

--- a/v2/frontend/src/core/signals/notes.ts
+++ b/v2/frontend/src/core/signals/notes.ts
@@ -7,17 +7,38 @@ import { listProjectNotes, createProjectNote, updateProjectNote, deleteProjectNo
 import type { ProjectNote } from '../types';
 
 const [projectNotes, setProjectNotes] = createSignal<ProjectNote[]>([]);
+const [stickyOverlayVisible, setStickyOverlayVisible] = createSignal(false);
+const [expandedNoteIds, setExpandedNoteIds] = createSignal<Set<string>>(new Set());
 
-export { projectNotes };
+export { projectNotes, stickyOverlayVisible, expandedNoteIds };
+
+export function toggleNoteExpanded(id: string): void {
+  setExpandedNoteIds(prev => {
+    const next = new Set(prev);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    return next;
+  });
+}
+
+export function setNoteExpanded(id: string, open: boolean): void {
+  setExpandedNoteIds(prev => {
+    const next = new Set(prev);
+    if (open) next.add(id); else next.delete(id);
+    return next;
+  });
+}
+
+export function toggleStickyOverlay(): void {
+  setStickyOverlayVisible(!stickyOverlayVisible());
+}
 
 export function bootstrapProjectNotes(): void {
-  // Reload notes when active project changes
   createEffect(on(() => activeProject()?.id, (projId) => {
     if (!projId) { setProjectNotes([]); return; }
     loadNotes(projId);
   }));
 
-  // Listen for note events from the Go backend
   onWailsEvent('note:created', () => {
     const projId = activeProject()?.id;
     if (projId) loadNotes(projId);

--- a/v2/frontend/src/core/types/index.ts
+++ b/v2/frontend/src/core/types/index.ts
@@ -386,6 +386,8 @@ export interface ProjectNote {
   body: string;
   pinned: boolean;
   position: number;
+  pos_x: number;
+  pos_y: number;
   created_at: number;
   updated_at: number;
 }

--- a/v2/frontend/src/shared/ProjectNotes/NoteCard.tsx
+++ b/v2/frontend/src/shared/ProjectNotes/NoteCard.tsx
@@ -71,16 +71,15 @@ export function NoteCard(props: NoteCardProps) {
   // ── GSAP entrance animation ─────────────────────────────────────────────
 
   onMount(() => {
-    gsap.from(cardRef, {
-      scale: 0.9,
-      opacity: 0,
-      duration: 0.3,
-      ease: 'back.out(1.7)',
-    });
+    gsap.fromTo(cardRef,
+      { scale: 0.9, opacity: 0 },
+      { scale: 1, opacity: 1, duration: 0.3, ease: 'back.out(1.7)', clearProps: 'opacity,transform' },
+    );
   });
 
   onCleanup(() => {
     if (debounceTimer) clearTimeout(debounceTimer);
+    gsap.killTweensOf(cardRef);
   });
 
   // ── Inline editing handlers ─────────────────────────────────────────────

--- a/v2/frontend/src/shared/ProjectNotes/ProjectNotes.tsx
+++ b/v2/frontend/src/shared/ProjectNotes/ProjectNotes.tsx
@@ -45,20 +45,18 @@ export function ProjectNotes() {
     } else {
       // Expand
       gsap.to(chevronRef, { rotation: 90, duration: 0.2, ease: 'power2.inOut' });
-      gsap.set(gridRef, { height: 'auto', opacity: 1 });
-      gsap.from(gridRef, { height: 0, opacity: 0, duration: 0.25, ease: 'power2.inOut' });
-      // Stagger cards entrance
+      gsap.killTweensOf(gridRef);
+      gsap.fromTo(gridRef,
+        { height: 0, opacity: 0 },
+        { height: 'auto', opacity: 1, duration: 0.25, ease: 'power2.inOut', clearProps: 'opacity' },
+      );
       const cards = gridRef.children;
       if (cards.length > 0) {
-        gsap.from(cards, {
-          opacity: 0,
-          y: 8,
-          scale: 0.95,
-          stagger: 0.04,
-          duration: 0.3,
-          ease: 'back.out(1.2)',
-          delay: 0.1,
-        });
+        gsap.killTweensOf(cards);
+        gsap.fromTo(cards,
+          { opacity: 0, y: 8, scale: 0.95 },
+          { opacity: 1, y: 0, scale: 1, stagger: 0.04, duration: 0.3, ease: 'back.out(1.2)', delay: 0.1, clearProps: 'opacity,transform' },
+        );
       }
     }
   }
@@ -71,22 +69,27 @@ export function ProjectNotes() {
         setCollapsed(false);
         void setPref(PREF_KEY, 'false');
         gsap.to(chevronRef, { rotation: 90, duration: 0.2, ease: 'power2.inOut' });
-        gsap.set(gridRef, { height: 'auto', opacity: 1 });
-        gsap.from(gridRef, { height: 0, opacity: 0, duration: 0.25, ease: 'power2.inOut' });
+        gsap.killTweensOf(gridRef);
+        gsap.fromTo(gridRef,
+          { height: 0, opacity: 0 },
+          { height: 'auto', opacity: 1, duration: 0.25, ease: 'power2.inOut', clearProps: 'opacity' },
+        );
         const cards = gridRef.children;
         if (cards.length > 0) {
-          gsap.from(cards, {
-            opacity: 0, y: 8, scale: 0.95,
-            stagger: 0.04, duration: 0.3, ease: 'back.out(1.2)', delay: 0.1,
-          });
+          gsap.killTweensOf(cards);
+          gsap.fromTo(cards,
+            { opacity: 0, y: 8, scale: 0.95 },
+            { opacity: 1, y: 0, scale: 1, stagger: 0.04, duration: 0.3, ease: 'back.out(1.2)', delay: 0.1, clearProps: 'opacity,transform' },
+          );
         }
       } else {
         const lastCard = gridRef.children[gridRef.children.length - 1];
         if (lastCard) {
-          gsap.from(lastCard, {
-            opacity: 0, y: 8, scale: 0.95,
-            duration: 0.3, ease: 'back.out(1.2)',
-          });
+          gsap.killTweensOf(lastCard);
+          gsap.fromTo(lastCard,
+            { opacity: 0, y: 8, scale: 0.95 },
+            { opacity: 1, y: 0, scale: 1, duration: 0.3, ease: 'back.out(1.2)', clearProps: 'opacity,transform' },
+          );
         }
       }
     }

--- a/v2/frontend/src/shared/StickyNotesOverlay/NotesDrawerCard.tsx
+++ b/v2/frontend/src/shared/StickyNotesOverlay/NotesDrawerCard.tsx
@@ -1,0 +1,144 @@
+// Author: Subash Karki
+
+import { createSignal, createMemo, Show } from 'solid-js';
+import { Collapsible } from '@kobalte/core/collapsible';
+import { ContextMenu } from '@kobalte/core/context-menu';
+import { ChevronRight, Maximize2, Pin, Trash2, Trash } from 'lucide-solid';
+import { TipTapEditor } from '@/shared/TipTapEditor';
+import { addTabWithData } from '@/core/panes/signals';
+import { saveNote, removeNote, expandedNoteIds, setNoteExpanded } from '@/core/signals/notes';
+import { activeProject } from '@/core/signals/worktrees';
+import {
+  contextMenuContent,
+  contextMenuItem,
+  contextMenuItemDanger,
+  contextMenuSeparator,
+} from '@/styles/sidebar.css';
+import * as styles from './StickyNotesOverlay.css';
+import type { ProjectNote } from '@/core/types';
+
+const NOTE_COLORS: Record<string, string> = {
+  todo: '#f59e0b',
+  idea: '#3b82f6',
+  bug: '#ef4444',
+  note: '#00d4ff',
+};
+
+interface NotesDrawerCardProps {
+  note: ProjectNote;
+}
+
+export function NotesDrawerCard(props: NotesDrawerCardProps) {
+  const [draft, setDraft] = createSignal('');
+
+  const expanded = () => expandedNoteIds().has(props.note.id);
+  const noteColor = createMemo(() => NOTE_COLORS[props.note.type] ?? '#00d4ff');
+
+  function handleOpen(open: boolean) {
+    if (open) setDraft(props.note.body);
+    setNoteExpanded(props.note.id, open);
+  }
+
+  async function handleSave() {
+    await saveNote(props.note.id, props.note.title, draft(), props.note.type, props.note.pinned);
+    setNoteExpanded(props.note.id, false);
+  }
+
+  function handleCancel() {
+    setNoteExpanded(props.note.id, false);
+  }
+
+  function expandNote(e: MouseEvent) {
+    e.stopPropagation();
+    addTabWithData('notes', props.note.title || 'Note', {
+      noteId: props.note.id,
+      projectId: activeProject()?.id,
+    });
+  }
+
+  function changeType(newType: string) {
+    saveNote(props.note.id, props.note.title, props.note.body, newType, props.note.pinned);
+  }
+
+  function togglePin() {
+    saveNote(props.note.id, props.note.title, props.note.body, props.note.type, !props.note.pinned);
+  }
+
+  async function deleteNote() {
+    await removeNote(props.note.id);
+  }
+
+  return (
+    <ContextMenu>
+      <ContextMenu.Trigger as="div">
+        <Collapsible open={expanded()} onOpenChange={handleOpen}>
+          <div class={styles.noteCard} style={{ '--note-color': noteColor() }}>
+            <div class={styles.noteColorBar} />
+            <Collapsible.Trigger class={styles.noteHeader}>
+              <ChevronRight
+                size={12}
+                class={styles.noteChevron}
+                style={{ transform: expanded() ? 'rotate(90deg)' : 'rotate(0deg)' }}
+              />
+              <Show when={props.note.pinned}>
+                <Pin size={10} class={styles.notePinIcon} />
+              </Show>
+              <span class={styles.noteTitle}>{props.note.title || 'Untitled'}</span>
+              <span class={styles.noteTypeBadge}>{props.note.type}</span>
+              <div class={styles.noteActions}>
+                <button class={styles.noteActionBtn} onClick={expandNote} title="Open in tab">
+                  <Maximize2 size={12} />
+                </button>
+                <button class={styles.noteActionBtnDanger} onClick={(e) => { e.stopPropagation(); deleteNote(); }} title="Delete">
+                  <Trash size={12} />
+                </button>
+              </div>
+            </Collapsible.Trigger>
+            <Collapsible.Content class={styles.noteContent}>
+              <TipTapEditor
+                content={draft()}
+                onChange={setDraft}
+                placeholder="Start writing..."
+                toolbar
+              />
+              <div class={styles.editorActions}>
+                <button class={styles.cancelBtn} onClick={handleCancel}>Cancel</button>
+                <button class={styles.saveBtn} onClick={handleSave}>Save</button>
+              </div>
+            </Collapsible.Content>
+          </div>
+        </Collapsible>
+      </ContextMenu.Trigger>
+
+      <ContextMenu.Portal>
+        <ContextMenu.Content class={contextMenuContent}>
+          <ContextMenu.Item class={contextMenuItem} onSelect={() => handleOpen(true)}>
+            Edit
+          </ContextMenu.Item>
+          <ContextMenu.Sub gutter={4}>
+            <ContextMenu.SubTrigger class={styles.contextMenuSubTrigger}>
+              Type
+              <ChevronRight size={12} />
+            </ContextMenu.SubTrigger>
+            <ContextMenu.Portal>
+              <ContextMenu.SubContent class={styles.contextMenuSubContent}>
+                <ContextMenu.Item class={contextMenuItem} onSelect={() => changeType('todo')}>Todo</ContextMenu.Item>
+                <ContextMenu.Item class={contextMenuItem} onSelect={() => changeType('idea')}>Idea</ContextMenu.Item>
+                <ContextMenu.Item class={contextMenuItem} onSelect={() => changeType('bug')}>Bug</ContextMenu.Item>
+                <ContextMenu.Item class={contextMenuItem} onSelect={() => changeType('note')}>Note</ContextMenu.Item>
+              </ContextMenu.SubContent>
+            </ContextMenu.Portal>
+          </ContextMenu.Sub>
+          <ContextMenu.Item class={contextMenuItem} onSelect={togglePin}>
+            {props.note.pinned ? 'Unpin' : 'Pin to Top'}
+          </ContextMenu.Item>
+          <ContextMenu.Separator class={contextMenuSeparator} />
+          <ContextMenu.Item class={`${contextMenuItem} ${contextMenuItemDanger}`} onSelect={deleteNote}>
+            <Trash2 size={14} />
+            Delete
+          </ContextMenu.Item>
+        </ContextMenu.Content>
+      </ContextMenu.Portal>
+    </ContextMenu>
+  );
+}

--- a/v2/frontend/src/shared/StickyNotesOverlay/StickyNotesOverlay.css.ts
+++ b/v2/frontend/src/shared/StickyNotesOverlay/StickyNotesOverlay.css.ts
@@ -1,0 +1,323 @@
+// Author: Subash Karki
+
+import { style, globalStyle } from '@vanilla-extract/css';
+import { vars } from '@/styles/theme.css';
+
+// ── Drawer content ──────────────────────────────────────────────────────────
+
+export const drawerContent = style({
+  flex: 1,
+  overflow: 'auto',
+  padding: `${vars.space.md} ${vars.space.xl}`,
+});
+
+export const addNoteBtn = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '28px',
+  height: '28px',
+  borderRadius: vars.radius.sm,
+  border: `1px solid ${vars.color.border}`,
+  background: 'transparent',
+  color: vars.color.textSecondary,
+  cursor: 'pointer',
+  transition: `all 150ms ease`,
+  ':hover': {
+    color: vars.color.accent,
+    borderColor: `color-mix(in srgb, ${vars.color.accent} 45%, ${vars.color.border})`,
+    background: `color-mix(in srgb, ${vars.color.accent} 12%, transparent)`,
+  },
+});
+
+// ── Notes list ──────────────────────────────────────────────────────────────
+
+export const notesList = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.space.sm,
+});
+
+// ── Note card ───────────────────────────────────────────────────────────────
+
+export const noteCard = style({
+  borderRadius: vars.radius.md,
+  background: vars.color.bgSecondary,
+  border: `1px solid color-mix(in srgb, ${vars.color.accent} 15%, ${vars.color.border})`,
+  overflow: 'hidden',
+  transition: `border-color ${vars.animation.fast} ease`,
+  ':hover': {
+    borderColor: `color-mix(in srgb, ${vars.color.accent} 35%, ${vars.color.border})`,
+  },
+});
+
+export const noteColorBar = style({
+  height: '3px',
+  width: '100%',
+  background: 'var(--note-color)',
+});
+
+export const noteHeader = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: vars.space.xs,
+  padding: `${vars.space.sm} ${vars.space.md}`,
+  width: '100%',
+  border: 'none',
+  background: 'transparent',
+  color: vars.color.textPrimary,
+  cursor: 'pointer',
+  fontFamily: vars.font.body,
+  fontSize: vars.fontSize.sm,
+  textAlign: 'left',
+  outline: 'none',
+  ':hover': {
+    background: vars.color.bgHover,
+  },
+});
+
+export const noteChevron = style({
+  color: vars.color.textSecondary,
+  flexShrink: 0,
+  transition: `transform ${vars.animation.fast} ease`,
+});
+
+export const notePinIcon = style({
+  color: vars.color.warning,
+  flexShrink: 0,
+  opacity: 0.8,
+});
+
+export const noteTitle = style({
+  flex: 1,
+  fontWeight: 600,
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+});
+
+export const noteTypeBadge = style({
+  fontFamily: vars.font.mono,
+  fontSize: '0.55rem',
+  textTransform: 'uppercase',
+  letterSpacing: '0.08em',
+  color: 'var(--note-color)',
+  flexShrink: 0,
+});
+
+export const noteActions = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '2px',
+  flexShrink: 0,
+  opacity: 0,
+  transition: `opacity ${vars.animation.fast} ease`,
+});
+
+// Show actions on card hover
+globalStyle(`${noteCard}:hover ${noteActions}`, {
+  opacity: 1,
+});
+
+export const noteActionBtn = style({
+  width: '22px',
+  height: '22px',
+  borderRadius: vars.radius.sm,
+  background: 'transparent',
+  border: 'none',
+  color: vars.color.textSecondary,
+  cursor: 'pointer',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: 0,
+  transition: `all ${vars.animation.fast} ease`,
+  ':hover': {
+    color: vars.color.accent,
+    background: `color-mix(in srgb, ${vars.color.accent} 12%, transparent)`,
+  },
+});
+
+export const noteActionBtnDanger = style({
+  width: '22px',
+  height: '22px',
+  borderRadius: vars.radius.sm,
+  background: 'transparent',
+  border: 'none',
+  color: vars.color.textSecondary,
+  cursor: 'pointer',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: 0,
+  transition: `all ${vars.animation.fast} ease`,
+  ':hover': {
+    color: vars.color.danger,
+    background: `color-mix(in srgb, ${vars.color.danger} 12%, transparent)`,
+  },
+});
+
+// ── Collapsible content ─────────────────────────────────────────────────────
+
+export const noteContent = style({
+  padding: `0 ${vars.space.md} ${vars.space.md}`,
+  borderTop: `1px solid color-mix(in srgb, ${vars.color.accent} 8%, ${vars.color.border})`,
+});
+
+export const noteBody = style({
+  fontFamily: vars.font.mono,
+  fontSize: '0.7rem',
+  color: vars.color.textSecondary,
+  lineHeight: '1.6',
+  cursor: 'text',
+  padding: `${vars.space.sm} 0`,
+  minHeight: '40px',
+});
+
+// Markdown styles inside noteBody
+globalStyle(`${noteBody} p`, { margin: '0 0 4px 0', fontSize: 'inherit' });
+globalStyle(`${noteBody} ul, ${noteBody} ol`, { margin: '0 0 4px 0', paddingLeft: '16px', fontSize: 'inherit' });
+globalStyle(`${noteBody} li`, { margin: 0, fontSize: 'inherit' });
+globalStyle(`${noteBody} code`, {
+  fontFamily: 'inherit',
+  background: `color-mix(in srgb, ${vars.color.accent} 10%, transparent)`,
+  borderRadius: '2px',
+  padding: '0 3px',
+});
+globalStyle(`${noteBody} a`, { color: vars.color.textLink, textDecoration: 'none' });
+globalStyle(`${noteBody} strong`, { fontWeight: 600, color: vars.color.textPrimary });
+globalStyle(`${noteBody} h1, ${noteBody} h2, ${noteBody} h3, ${noteBody} h4`, {
+  margin: '0 0 4px 0', fontSize: 'inherit', fontWeight: 600, color: vars.color.textPrimary,
+});
+
+export const notePlaceholder = style({
+  color: vars.color.textDisabled,
+  fontStyle: 'italic',
+  fontSize: '0.7rem',
+  fontFamily: vars.font.mono,
+});
+
+export const noteTextarea = style({
+  width: '100%',
+  minHeight: '100px',
+  background: 'transparent',
+  border: 'none',
+  outline: 'none',
+  resize: 'vertical',
+  fontFamily: vars.font.mono,
+  fontSize: '0.7rem',
+  color: vars.color.textPrimary,
+  lineHeight: '1.6',
+  padding: `${vars.space.sm} 0`,
+  '::placeholder': {
+    color: vars.color.textDisabled,
+  },
+});
+
+// ── Empty state ─────────────────────────────────────────────────────────────
+
+export const emptyState = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: vars.space.md,
+  padding: `${vars.space.xl} 0`,
+  color: vars.color.textDisabled,
+});
+
+export const emptyText = style({
+  fontFamily: vars.font.body,
+  fontSize: vars.fontSize.sm,
+  color: vars.color.textSecondary,
+  margin: 0,
+});
+
+export const emptyCreateBtn = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: vars.space.xs,
+  padding: `${vars.space.sm} ${vars.space.lg}`,
+  borderRadius: vars.radius.md,
+  background: `color-mix(in srgb, ${vars.color.accent} 15%, ${vars.color.bgSecondary})`,
+  border: `1px solid color-mix(in srgb, ${vars.color.accent} 30%, ${vars.color.border})`,
+  color: vars.color.accent,
+  fontFamily: vars.font.body,
+  fontSize: vars.fontSize.sm,
+  fontWeight: 600,
+  cursor: 'pointer',
+  transition: `all ${vars.animation.fast} ease`,
+  ':hover': {
+    background: `color-mix(in srgb, ${vars.color.accent} 25%, ${vars.color.bgSecondary})`,
+    borderColor: vars.color.accent,
+  },
+});
+
+// ── Save / Cancel buttons ───────────────────────────────────────────────────
+
+export const editorActions = style({
+  display: 'flex',
+  justifyContent: 'flex-end',
+  gap: vars.space.sm,
+  paddingTop: vars.space.sm,
+  borderTop: `1px solid color-mix(in srgb, ${vars.color.accent} 8%, ${vars.color.border})`,
+});
+
+export const saveBtn = style({
+  padding: `${vars.space.xs} ${vars.space.lg}`,
+  borderRadius: vars.radius.sm,
+  border: 'none',
+  background: vars.color.accent,
+  color: vars.color.bgPrimary,
+  fontFamily: vars.font.body,
+  fontSize: vars.fontSize.xs,
+  fontWeight: 600,
+  cursor: 'pointer',
+  transition: `opacity ${vars.animation.fast} ease`,
+  ':hover': {
+    opacity: 0.85,
+  },
+});
+
+export const cancelBtn = style({
+  padding: `${vars.space.xs} ${vars.space.md}`,
+  borderRadius: vars.radius.sm,
+  border: `1px solid ${vars.color.border}`,
+  background: 'transparent',
+  color: vars.color.textSecondary,
+  fontFamily: vars.font.body,
+  fontSize: vars.fontSize.xs,
+  cursor: 'pointer',
+  transition: `all ${vars.animation.fast} ease`,
+  ':hover': {
+    color: vars.color.textPrimary,
+    background: vars.color.bgHover,
+  },
+});
+
+// ── Context menu (reused from NoteCard) ─────────────────────────────────────
+
+export const contextMenuSubTrigger = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: vars.space.sm,
+  padding: `${vars.space.xs} ${vars.space.md}`,
+  fontSize: vars.fontSize.sm,
+  color: vars.color.textPrimary,
+  cursor: 'pointer',
+  outline: 'none',
+  transition: `background ${vars.animation.fast} ease`,
+  ':hover': { backgroundColor: vars.color.bgHover },
+  ':focus-visible': { backgroundColor: vars.color.bgHover },
+});
+
+export const contextMenuSubContent = style({
+  backgroundColor: vars.color.bgTertiary,
+  border: `1px solid ${vars.color.border}`,
+  borderRadius: vars.radius.md,
+  padding: `${vars.space.xs} 0`,
+  boxShadow: vars.shadow.md,
+  minWidth: '120px',
+  zIndex: 9100,
+});

--- a/v2/frontend/src/shared/StickyNotesOverlay/StickyNotesOverlay.tsx
+++ b/v2/frontend/src/shared/StickyNotesOverlay/StickyNotesOverlay.tsx
@@ -1,0 +1,59 @@
+// Author: Subash Karki
+
+import { For, Show, createSignal } from 'solid-js';
+import { StickyNote, Plus } from 'lucide-solid';
+import { PhantomDrawer } from '../PhantomDrawer/PhantomDrawer';
+import { stickyOverlayVisible, toggleStickyOverlay, projectNotes } from '@/core/signals/notes';
+import { NotesDrawerCard } from './NotesDrawerCard';
+import { CreateNoteDialog } from '../ProjectNotes/CreateNoteDialog';
+import * as styles from './StickyNotesOverlay.css';
+
+export function StickyNotesOverlay() {
+  const [createOpen, setCreateOpen] = createSignal(false);
+
+  return (
+    <>
+      <PhantomDrawer
+        open={stickyOverlayVisible}
+        onOpenChange={(open) => { if (!open) toggleStickyOverlay(); }}
+        title="NOTES"
+        modal={() => false}
+        headerTrailing={
+          <button
+            class={styles.addNoteBtn}
+            onClick={() => setCreateOpen(true)}
+            title="New note"
+          >
+            <Plus size={14} />
+          </button>
+        }
+      >
+        <div class={styles.drawerContent}>
+          <Show
+            when={projectNotes().length > 0}
+            fallback={
+              <div class={styles.emptyState}>
+                <StickyNote size={32} />
+                <p class={styles.emptyText}>No notes yet</p>
+                <button class={styles.emptyCreateBtn} onClick={() => setCreateOpen(true)}>
+                  <Plus size={14} />
+                  Create a note
+                </button>
+              </div>
+            }
+          >
+            <div class={styles.notesList}>
+              <For each={projectNotes()}>
+                {(note) => <NotesDrawerCard note={note} />}
+              </For>
+            </div>
+          </Show>
+        </div>
+      </PhantomDrawer>
+      <CreateNoteDialog
+        open={() => createOpen()}
+        onClose={() => setCreateOpen(false)}
+      />
+    </>
+  );
+}

--- a/v2/frontend/src/shared/StickyNotesOverlay/index.ts
+++ b/v2/frontend/src/shared/StickyNotesOverlay/index.ts
@@ -1,0 +1,2 @@
+// Author: Subash Karki
+export { StickyNotesOverlay } from './StickyNotesOverlay';

--- a/v2/internal/app/bindings_notes.go
+++ b/v2/internal/app/bindings_notes.go
@@ -33,6 +33,8 @@ type ProjectNoteWire struct {
 	Body      string `json:"body"`
 	Pinned    bool   `json:"pinned"`
 	Position  int    `json:"position"`
+	PosX      int    `json:"pos_x"`
+	PosY      int    `json:"pos_y"`
 	CreatedAt int64  `json:"created_at"`
 	UpdatedAt int64  `json:"updated_at"`
 }
@@ -46,6 +48,8 @@ func noteToWire(n db.ProjectNote) ProjectNoteWire {
 		Body:      n.Body,
 		Pinned:    n.Pinned != 0,
 		Position:  int(n.Position),
+		PosX:      int(n.PosX),
+		PosY:      int(n.PosY),
 		CreatedAt: n.CreatedAt,
 		UpdatedAt: n.UpdatedAt,
 	}
@@ -95,6 +99,8 @@ func (a *App) CreateProjectNote(projectID, noteType, title string) (*ProjectNote
 		Body:      "",
 		Pinned:    0,
 		Position:  count + 1,
+		PosX:      100 + int64(count)*30,
+		PosY:      100 + int64(count)*30,
 		CreatedAt: now,
 		UpdatedAt: now,
 	}
@@ -113,6 +119,8 @@ func (a *App) CreateProjectNote(projectID, noteType, title string) (*ProjectNote
 		Body:      "",
 		Pinned:    false,
 		Position:  int(count + 1),
+		PosX:      100 + int(count)*30,
+		PosY:      100 + int(count)*30,
 		CreatedAt: now,
 		UpdatedAt: now,
 	}
@@ -149,6 +157,8 @@ func (a *App) UpdateProjectNote(id, title, body, noteType string, pinned bool) e
 		Type:      noteType,
 		Pinned:    pinnedInt,
 		Position:  existing.Position,
+		PosX:      existing.PosX,
+		PosY:      existing.PosY,
 		UpdatedAt: now,
 		ID:        id,
 	}
@@ -157,6 +167,39 @@ func (a *App) UpdateProjectNote(id, title, body, noteType string, pinned bool) e
 	if err := wq.UpdateProjectNote(a.ctx, params); err != nil {
 		log.Error("UpdateProjectNote: update failed", "id", id, "err", err)
 		return fmt.Errorf("UpdateProjectNote: update: %w", err)
+	}
+
+	wailsRuntime.EventsEmit(a.ctx, EventNoteUpdated, map[string]interface{}{
+		"projectId": existing.ProjectID,
+		"noteId":    id,
+	})
+
+	return nil
+}
+
+// UpdateNotePosition updates a note's floating position (x, y).
+// Emits "note:updated" with { projectId, noteId }.
+func (a *App) UpdateNotePosition(id string, posX, posY int) error {
+	now := time.Now().Unix()
+
+	rq := db.New(a.DB.Reader)
+	existing, err := rq.GetProjectNote(a.ctx, id)
+	if err != nil {
+		log.Error("UpdateNotePosition: get failed", "id", id, "err", err)
+		return fmt.Errorf("UpdateNotePosition: get: %w", err)
+	}
+
+	params := db.UpdateNotePositionParams{
+		PosX:      int64(posX),
+		PosY:      int64(posY),
+		UpdatedAt: now,
+		ID:        id,
+	}
+
+	wq := db.New(a.DB.Writer)
+	if err := wq.UpdateNotePosition(a.ctx, params); err != nil {
+		log.Error("UpdateNotePosition: update failed", "id", id, "err", err)
+		return fmt.Errorf("UpdateNotePosition: update: %w", err)
 	}
 
 	wailsRuntime.EventsEmit(a.ctx, EventNoteUpdated, map[string]interface{}{

--- a/v2/internal/db/migrations/018_note_positions.down.sql
+++ b/v2/internal/db/migrations/018_note_positions.down.sql
@@ -1,0 +1,18 @@
+-- Author: Subash Karki
+
+CREATE TABLE project_notes_backup AS SELECT id, project_id, type, title, body, pinned, position, created_at, updated_at FROM project_notes;
+DROP TABLE project_notes;
+CREATE TABLE project_notes (
+    id TEXT PRIMARY KEY,
+    project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    type TEXT NOT NULL DEFAULT 'note',
+    title TEXT NOT NULL DEFAULT '',
+    body TEXT NOT NULL DEFAULT '',
+    pinned INTEGER NOT NULL DEFAULT 0,
+    position INTEGER NOT NULL DEFAULT 0,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+);
+INSERT INTO project_notes SELECT * FROM project_notes_backup;
+DROP TABLE project_notes_backup;
+CREATE INDEX idx_project_notes_project ON project_notes(project_id);

--- a/v2/internal/db/migrations/018_note_positions.up.sql
+++ b/v2/internal/db/migrations/018_note_positions.up.sql
@@ -1,0 +1,4 @@
+-- Author: Subash Karki
+
+ALTER TABLE project_notes ADD COLUMN pos_x INTEGER NOT NULL DEFAULT 100;
+ALTER TABLE project_notes ADD COLUMN pos_y INTEGER NOT NULL DEFAULT 100;

--- a/v2/internal/db/models.go
+++ b/v2/internal/db/models.go
@@ -267,6 +267,8 @@ type ProjectNote struct {
 	Position  int64  `json:"position"`
 	CreatedAt int64  `json:"created_at"`
 	UpdatedAt int64  `json:"updated_at"`
+	PosX      int64  `json:"pos_x"`
+	PosY      int64  `json:"pos_y"`
 }
 
 type RecipeFavorite struct {

--- a/v2/internal/db/project_notes.sql.go
+++ b/v2/internal/db/project_notes.sql.go
@@ -21,8 +21,8 @@ func (q *Queries) CountProjectNotes(ctx context.Context, projectID string) (int6
 }
 
 const createProjectNote = `-- name: CreateProjectNote :exec
-INSERT INTO project_notes (id, project_id, type, title, body, pinned, position, created_at, updated_at)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+INSERT INTO project_notes (id, project_id, type, title, body, pinned, position, pos_x, pos_y, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 `
 
 type CreateProjectNoteParams struct {
@@ -33,6 +33,8 @@ type CreateProjectNoteParams struct {
 	Body      string `json:"body"`
 	Pinned    int64  `json:"pinned"`
 	Position  int64  `json:"position"`
+	PosX      int64  `json:"pos_x"`
+	PosY      int64  `json:"pos_y"`
 	CreatedAt int64  `json:"created_at"`
 	UpdatedAt int64  `json:"updated_at"`
 }
@@ -46,6 +48,8 @@ func (q *Queries) CreateProjectNote(ctx context.Context, arg CreateProjectNotePa
 		arg.Body,
 		arg.Pinned,
 		arg.Position,
+		arg.PosX,
+		arg.PosY,
 		arg.CreatedAt,
 		arg.UpdatedAt,
 	)
@@ -62,7 +66,7 @@ func (q *Queries) DeleteProjectNote(ctx context.Context, id string) error {
 }
 
 const getProjectNote = `-- name: GetProjectNote :one
-SELECT id, project_id, type, title, body, pinned, position, created_at, updated_at FROM project_notes WHERE id = ?
+SELECT id, project_id, type, title, body, pinned, position, created_at, updated_at, pos_x, pos_y FROM project_notes WHERE id = ?
 `
 
 func (q *Queries) GetProjectNote(ctx context.Context, id string) (ProjectNote, error) {
@@ -78,13 +82,15 @@ func (q *Queries) GetProjectNote(ctx context.Context, id string) (ProjectNote, e
 		&i.Position,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.PosX,
+		&i.PosY,
 	)
 	return i, err
 }
 
 const listProjectNotes = `-- name: ListProjectNotes :many
 
-SELECT id, project_id, type, title, body, pinned, position, created_at, updated_at FROM project_notes WHERE project_id = ? ORDER BY pinned DESC, position ASC, created_at DESC
+SELECT id, project_id, type, title, body, pinned, position, created_at, updated_at, pos_x, pos_y FROM project_notes WHERE project_id = ? ORDER BY pinned DESC, position ASC, created_at DESC
 `
 
 // Author: Subash Karki
@@ -107,6 +113,8 @@ func (q *Queries) ListProjectNotes(ctx context.Context, projectID string) ([]Pro
 			&i.Position,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.PosX,
+			&i.PosY,
 		); err != nil {
 			return nil, err
 		}
@@ -121,8 +129,29 @@ func (q *Queries) ListProjectNotes(ctx context.Context, projectID string) ([]Pro
 	return items, nil
 }
 
+const updateNotePosition = `-- name: UpdateNotePosition :exec
+UPDATE project_notes SET pos_x = ?, pos_y = ?, updated_at = ? WHERE id = ?
+`
+
+type UpdateNotePositionParams struct {
+	PosX      int64  `json:"pos_x"`
+	PosY      int64  `json:"pos_y"`
+	UpdatedAt int64  `json:"updated_at"`
+	ID        string `json:"id"`
+}
+
+func (q *Queries) UpdateNotePosition(ctx context.Context, arg UpdateNotePositionParams) error {
+	_, err := q.db.ExecContext(ctx, updateNotePosition,
+		arg.PosX,
+		arg.PosY,
+		arg.UpdatedAt,
+		arg.ID,
+	)
+	return err
+}
+
 const updateProjectNote = `-- name: UpdateProjectNote :exec
-UPDATE project_notes SET title = ?, body = ?, type = ?, pinned = ?, position = ?, updated_at = ? WHERE id = ?
+UPDATE project_notes SET title = ?, body = ?, type = ?, pinned = ?, position = ?, pos_x = ?, pos_y = ?, updated_at = ? WHERE id = ?
 `
 
 type UpdateProjectNoteParams struct {
@@ -131,6 +160,8 @@ type UpdateProjectNoteParams struct {
 	Type      string `json:"type"`
 	Pinned    int64  `json:"pinned"`
 	Position  int64  `json:"position"`
+	PosX      int64  `json:"pos_x"`
+	PosY      int64  `json:"pos_y"`
 	UpdatedAt int64  `json:"updated_at"`
 	ID        string `json:"id"`
 }
@@ -142,6 +173,8 @@ func (q *Queries) UpdateProjectNote(ctx context.Context, arg UpdateProjectNotePa
 		arg.Type,
 		arg.Pinned,
 		arg.Position,
+		arg.PosX,
+		arg.PosY,
 		arg.UpdatedAt,
 		arg.ID,
 	)

--- a/v2/internal/db/queries/project_notes.sql
+++ b/v2/internal/db/queries/project_notes.sql
@@ -7,11 +7,14 @@ SELECT * FROM project_notes WHERE project_id = ? ORDER BY pinned DESC, position 
 SELECT * FROM project_notes WHERE id = ?;
 
 -- name: CreateProjectNote :exec
-INSERT INTO project_notes (id, project_id, type, title, body, pinned, position, created_at, updated_at)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
+INSERT INTO project_notes (id, project_id, type, title, body, pinned, position, pos_x, pos_y, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 -- name: UpdateProjectNote :exec
-UPDATE project_notes SET title = ?, body = ?, type = ?, pinned = ?, position = ?, updated_at = ? WHERE id = ?;
+UPDATE project_notes SET title = ?, body = ?, type = ?, pinned = ?, position = ?, pos_x = ?, pos_y = ?, updated_at = ? WHERE id = ?;
+
+-- name: UpdateNotePosition :exec
+UPDATE project_notes SET pos_x = ?, pos_y = ?, updated_at = ? WHERE id = ?;
 
 -- name: DeleteProjectNote :exec
 DELETE FROM project_notes WHERE id = ?;


### PR DESCRIPTION
## Summary
- Add right-side PhantomDrawer for project sticky notes, toggled via **Cmd+Shift+N** from any pane
- Notes use Kobalte Collapsible cards with TipTap WYSIWYG rich text editor (bold, italic, lists, code, headings)
- Explicit **Save/Cancel** buttons instead of auto-save — no focus loss or reload flicker
- Inline delete (trash icon), expand-to-tab, context menu for type/pin/delete
- Empty state with "Create a note" button when no notes exist
- DB migration 018 adds `pos_x`/`pos_y` columns + `UpdateNotePosition` Go binding
- Fix GSAP `gsap.from()` dimming bug in ProjectNotes and NoteCard (same fix as quick action tiles)

## Test plan
- [ ] `Cmd+Shift+N` toggles notes drawer from any pane (terminal, editor, home)
- [ ] Create note via `+` button or empty state button
- [ ] Expand note, edit with TipTap toolbar, Save persists, Cancel discards
- [ ] Delete via trash icon or right-click context menu
- [ ] Type/Pin changes via context menu
- [ ] Expand-to-tab button opens full NotesPane
- [ ] Notes scoped per-project — switching projects shows that project's notes
- [ ] Adding notes in home pane no longer dims tiles (GSAP fix)

PR Generated with AI

Co-Authored-By: AI