### PR TITLE
fix: v2 hardening + feat: markdown preview

### DIFF
--- a/v2/frontend/src/app.tsx
+++ b/v2/frontend/src/app.tsx
@@ -1,12 +1,13 @@
 // Phantom — App shell (Wave 1: Worktree Workspace layout)
 // Author: Subash Karki
 
-import { createSignal, createEffect, onMount, onCleanup, Show, untrack } from 'solid-js';
+import { createSignal, createEffect, onMount, onCleanup, Show, untrack, ErrorBoundary } from 'solid-js';
 
 window.addEventListener('error', (e) => {
   if (e.message?.includes('ResizeObserver')) e.stopImmediatePropagation();
 });
 import { shadowMonarchDarkTheme } from './styles/theme.css';
+import { reducedMotion } from './styles/reset.css';
 import * as styles from './styles/app.css';
 import * as shellStyles from './styles/app-shell.css';
 import { isFullscreen, initFullscreenDetection, stopFullscreenDetection } from './core/signals/fullscreen';
@@ -58,6 +59,8 @@ import ComposerDrawer from './components/composer/ComposerDrawer';
 import ComposerStatusPill from './components/composer/ComposerStatusPill';
 import { DigestDrawer } from './shared/DigestDrawer/DigestDrawer';
 import { PerfOverlay } from './components/PerfOverlay/PerfOverlay';
+import { vars } from './styles/theme.css';
+import { setWindowVisible, windowVisible } from './core/signals/visibility';
 import { bootstrapProjectNotes } from './core/signals/notes';
 
 export function App() {
@@ -78,6 +81,8 @@ export function App() {
 
   onMount(async () => {
     document.body.classList.add(shadowMonarchDarkTheme);
+    // Apply reduced-motion class for a11y (prefers-reduced-motion media query)
+    document.documentElement.classList.add(reducedMotion);
 
     await waitForWails();
 
@@ -145,12 +150,14 @@ export function App() {
     // Notify Go backend of window focus/blur so background pollers can throttle.
     // Use both window focus/blur (covers app-level) and visibilitychange (covers
     // WebView tab/minimize) for robustness in Wails WebKit.
-    const handleFocus = () => window.go?.app?.App?.OnWindowFocused();
-    const handleBlur = () => window.go?.app?.App?.OnWindowBlurred();
+    const handleFocus = () => { setWindowVisible(true); window.go?.app?.App?.OnWindowFocused(); };
+    const handleBlur = () => { setWindowVisible(false); window.go?.app?.App?.OnWindowBlurred(); };
     const handleVisChange = () => {
       if (document.hidden) {
+        setWindowVisible(false);
         window.go?.app?.App?.OnWindowBlurred();
       } else {
+        setWindowVisible(true);
         window.go?.app?.App?.OnWindowFocused();
       }
     };
@@ -196,6 +203,14 @@ export function App() {
     }
   });
 
+  // Immediately refresh stale data when app becomes visible again
+  createEffect(() => {
+    if (windowVisible()) {
+      import('@/core/bindings').then(m => m.getSessions?.());
+      import('@/core/signals/worktrees').then(m => m.refreshAllWorktreeStatuses?.());
+      import('@/core/bindings/terminal').then(m => m.listTerminals?.());
+    }
+  });
 
   async function handleShutdown() {
     if (shuttingDown()) return;
@@ -304,29 +319,44 @@ export function App() {
       </Show>
 
       <Show when={ready() && !showOnboarding() && bootCeremonyDone()}>
-        <WindowDragStrip />
+        <ErrorBoundary fallback={(err, reset) => {
+          console.error('[ErrorBoundary:App]', err);
+          return (
+            <div style={{ display: 'flex', 'flex-direction': 'column', 'align-items': 'center', 'justify-content': 'center', height: '100%', gap: vars.space.md, color: vars.color.textPrimary }}>
+              <div style={{ 'font-family': vars.font.display, 'font-size': vars.fontSize.lg }}>Something went wrong</div>
+              <div style={{ 'font-family': vars.font.mono, 'font-size': vars.fontSize.xs, color: vars.color.textSecondary, 'max-width': '500px', 'text-align': 'center', overflow: 'hidden', 'text-overflow': 'ellipsis' }}>
+                {String(err)}
+              </div>
+              <button style={{ padding: `${vars.space.sm} ${vars.space.md}`, 'border-radius': vars.radius.md, background: vars.color.accent, color: vars.color.textInverse, border: 'none', cursor: 'pointer', 'font-family': vars.font.body }} onClick={() => reset()}>
+                Try Again
+              </button>
+            </div>
+          );
+        }}>
+          <WindowDragStrip />
 
-        <div class={shellStyles.mainContent}>
-          <Show when={activeTopTab() === 'system'}>
-            <SystemCockpit />
-          </Show>
+          <div class={shellStyles.mainContent}>
+            <Show when={activeTopTab() === 'system'}>
+              <SystemCockpit />
+            </Show>
 
-          <Show when={activeTopTab() === 'worktree'}>
-            <div class={shellStyles.threeColumnLayout}>
-              <WorktreeSidebar />
+            <Show when={activeTopTab() === 'worktree'}>
+              <div class={shellStyles.threeColumnLayout}>
+                <WorktreeSidebar />
 
-              <div class={shellStyles.centerWorkspace}>
-                <Show when={activeWorktreeId()} fallback={<WelcomePage />}>
-                  <Workspace />
+                <div class={shellStyles.centerWorkspace}>
+                  <Show when={activeWorktreeId()} fallback={<WelcomePage />}>
+                    <Workspace />
+                  </Show>
+                </div>
+
+                <Show when={activeWorktreeId()}>
+                  <RightSidebar />
                 </Show>
               </div>
-
-              <Show when={activeWorktreeId()}>
-                <RightSidebar />
-              </Show>
-            </div>
-          </Show>
-        </div>
+            </Show>
+          </div>
+        </ErrorBoundary>
       </Show>
 
       <DigestDrawer />

--- a/v2/frontend/src/components/ai-insight/AIInsightPanel.tsx
+++ b/v2/frontend/src/components/ai-insight/AIInsightPanel.tsx
@@ -10,6 +10,7 @@ import { activeWorktreeId } from '@/core/signals/app';
 import { getAIInsight } from '@/core/bindings';
 import type { AIInsightData, DecisionEntry } from '@/core/bindings';
 import { onWailsEvent } from '@/core/events';
+import { timeAgo } from '@/utils/format';
 import { vars } from '@/styles/theme.css';
 import * as styles from './AIInsightPanel.css';
 
@@ -39,18 +40,6 @@ const outcomeColor = (success: boolean | null): string => {
   if (success === true) return vars.color.success;
   if (success === false) return vars.color.danger;
   return vars.color.textDisabled;
-};
-
-const timeAgo = (iso: string): string => {
-  if (!iso) return '';
-  const diffMs = Date.now() - new Date(iso).getTime();
-  const mins = Math.floor(diffMs / 60_000);
-  if (mins < 1) return 'now';
-  if (mins < 60) return `${mins}m`;
-  const hrs = Math.floor(mins / 60);
-  if (hrs < 24) return `${hrs}h`;
-  const days = Math.floor(hrs / 24);
-  return `${days}d`;
 };
 
 const truncateGoal = (goal: string, max = 40): string => {

--- a/v2/frontend/src/components/composer/ComposerAgentPanel.tsx
+++ b/v2/frontend/src/components/composer/ComposerAgentPanel.tsx
@@ -6,6 +6,7 @@
 
 import { createSignal, onCleanup, For, Show } from 'solid-js';
 import { Check, X, Pin, Bot } from 'lucide-solid';
+import { formatTokens } from '@/utils/format';
 import * as styles from './ComposerAgentPanel.css';
 
 // ── Public types ────────────────────────────────────────────────────────
@@ -41,11 +42,6 @@ const formatElapsed = (startMs: number, endMs: number): string => {
   const m = Math.floor(totalSec / 60);
   const s = totalSec % 60;
   return `${m}m ${s}s`;
-};
-
-const formatTokens = (n: number): string => {
-  if (n >= 1000) return `${(n / 1000).toFixed(1)}K`;
-  return `${n}`;
 };
 
 const truncateResult = (text: string, max = 500): string =>

--- a/v2/frontend/src/components/composer/ComposerStatusStrip.tsx
+++ b/v2/frontend/src/components/composer/ComposerStatusStrip.tsx
@@ -2,23 +2,11 @@
 
 import { type Component, Show } from 'solid-js'
 import type { ComposerState } from '@/core/composer/types'
+import { formatTokens, formatCostUsd } from '@/utils/format'
 import * as css from './ComposerStatusStrip.css'
 
 interface ComposerStatusStripProps {
   state: ComposerState
-}
-
-const formatTokens = (n: number): string => {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`
-  return String(n)
-}
-
-const formatCost = (usd: number): string => {
-  if (usd === 0) return ''
-  if (usd < 0.01) return `$${usd.toFixed(4)}`
-  if (usd < 1) return `$${usd.toFixed(3)}`
-  return `$${usd.toFixed(2)}`
 }
 
 const ComposerStatusStrip: Component<ComposerStatusStripProps> = (props) => {
@@ -64,7 +52,7 @@ const ComposerStatusStrip: Component<ComposerStatusStripProps> = (props) => {
       </Show>
       <Show when={props.state.totalCostUsd > 0}>
         <span class={css.separator}>·</span>
-        <span class={css.tokenCount}>{formatCost(props.state.totalCostUsd)}</span>
+        <span class={css.tokenCount}>{formatCostUsd(props.state.totalCostUsd)}</span>
       </Show>
       <Show when={contextPct() > 0}>
         <span class={css.separator}>·</span>

--- a/v2/frontend/src/components/composer/ContextGauge.tsx
+++ b/v2/frontend/src/components/composer/ContextGauge.tsx
@@ -2,17 +2,12 @@
 
 import { Show, createMemo, type Component } from 'solid-js';
 import type { ComposerState } from '@/core/composer/types';
+import { formatTokens } from '@/utils/format';
 import * as s from './ContextGauge.css';
 
 interface ContextGaugeProps {
   state: ComposerState;
 }
-
-const formatTokenCount = (n: number): string => {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
-  return `${n}`;
-};
 
 const ContextGauge: Component<ContextGaugeProps> = (props) => {
   const pct = createMemo(() => props.state.contextUsedPct);
@@ -53,7 +48,7 @@ const ContextGauge: Component<ContextGaugeProps> = (props) => {
           aria-valuemin={0}
           aria-valuemax={100}
           aria-label={`Context window usage: ${pct().toFixed(0)}%`}
-          title={`Session: ${formatTokenCount(totalIn())} in / ${formatTokenCount(totalOut())} out · $${cost().toFixed(4)} · ${pct().toFixed(0)}% context`}
+          title={`Session: ${formatTokens(totalIn())} in / ${formatTokens(totalOut())} out · $${cost().toFixed(4)} · ${pct().toFixed(0)}% context`}
         >
           <div
             class={s.gaugeFill}
@@ -63,7 +58,7 @@ const ContextGauge: Component<ContextGaugeProps> = (props) => {
             }}
           />
           <span class={s.gaugeLabel}>
-            {formatTokenCount(totalIn())} in / {formatTokenCount(totalOut())} out · ${cost().toFixed(4)} · {pct().toFixed(0)}%
+            {formatTokens(totalIn())} in / {formatTokens(totalOut())} out · ${cost().toFixed(4)} · {pct().toFixed(0)}%
           </span>
         </div>
       </div>

--- a/v2/frontend/src/components/composer/chips/StatusChipStrip.tsx
+++ b/v2/frontend/src/components/composer/chips/StatusChipStrip.tsx
@@ -1,6 +1,7 @@
 // Author: Subash Karki
 import { Show, createMemo } from 'solid-js'
 import type { ComposerState } from '@/core/composer/types'
+import { formatTokens, formatCostUsd } from '@/utils/format'
 import { chipBase, chipStatus } from './Chip.css'
 import { SessionLifecycleChip } from './SessionLifecycleChip'
 import { statusStrip } from './StatusChipStrip.css'
@@ -8,16 +9,6 @@ import { statusStrip } from './StatusChipStrip.css'
 interface StatusChipStripProps {
   state: ComposerState
   turnCount: number
-}
-
-function formatTokens(n: number): string {
-  if (n >= 1000) return `${(n / 1000).toFixed(1)}k`
-  return String(n)
-}
-
-function formatCost(usd: number): string {
-  if (usd < 0.01) return '<$0.01'
-  return `$${usd.toFixed(2)}`
 }
 
 export function StatusChipStrip(props: StatusChipStripProps) {
@@ -39,7 +30,7 @@ export function StatusChipStrip(props: StatusChipStripProps) {
       </Show>
       <Show when={s().totalCostUsd > 0}>
         <span class={`${chipBase} ${chipStatus.neutral}`}>
-          Cost: {formatCost(s().totalCostUsd)}
+          Cost: {formatCostUsd(s().totalCostUsd)}
         </span>
       </Show>
       <Show when={contextPct() > 0}>

--- a/v2/frontend/src/components/composer/input/ComposerInput.tsx
+++ b/v2/frontend/src/components/composer/input/ComposerInput.tsx
@@ -9,6 +9,7 @@ import {
 import type { ComposerMode, PermissionMode, EffortLevel, EditorContext } from '@/core/composer/types'
 import { showWarningToast } from '@/shared/Toast/Toast'
 import { Tip } from '@/shared/Tip/Tip'
+import { formatTokens } from '@/utils/format'
 import { ModeToggle } from './ModeToggle'
 import { ModelSelector } from './ModelSelector'
 import { ContextChips } from './ContextChips'
@@ -75,12 +76,6 @@ interface ComposerInputProps {
 
 /** Rough char-to-token estimate (same heuristic V1 uses). */
 const estimateTokens = (text: string): number => Math.ceil(text.length / 4)
-
-/** Format token count for display. */
-const formatTokens = (n: number): string => {
-  if (n >= 1000) return `${(n / 1000).toFixed(1)}k`
-  return String(n)
-}
 
 export const ComposerInput = (props: ComposerInputProps) => {
   const [text, setText] = createSignal('')

--- a/v2/frontend/src/components/panes/FileViewer.tsx
+++ b/v2/frontend/src/components/panes/FileViewer.tsx
@@ -2,6 +2,9 @@
 
 import { createSignal, onMount, onCleanup, Show, For, createEffect, on, createMemo } from 'solid-js';
 import { Portal } from 'solid-js/web';
+import { marked } from 'marked';
+import DOMPurify from 'dompurify';
+import 'highlight.js/styles/github-dark-dimmed.min.css';
 import { detectLanguage } from '@/core/editor/language';
 import { readFileContents, writeFileContents } from '@/core/bindings/editor';
 import { readPlanFile, writePlanFile } from '@/core/bindings/plans';
@@ -20,9 +23,11 @@ import CodeMirrorEditor from '@/core/editor/CodeMirrorEditor';
 import DiffViewer from '@/shared/DiffViewer/DiffViewer';
 import { loadLanguage } from '@/core/editor/cm-languages';
 import { phantomThemeExtension } from '@/core/editor/cm-theme';
+import { highlightCode } from '@/core/composer/highlighter';
 import { TextWrap, Clipboard, X as XIcon } from 'lucide-solid';
 import type { Extension } from '@codemirror/state';
 import * as styles from '@/styles/viewer.css';
+import * as markdownStyles from '@/styles/markdown-preview.css';
 import * as sidebarStyles from '@/styles/right-sidebar.css';
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -70,6 +75,7 @@ export default function FileViewer(props: FileViewerProps) {
   const [loading, setLoading] = createSignal(true);
   const [mode, setMode] = createSignal<'file' | 'diff'>('file');
   const [lineWrapping, setLineWrapping] = createSignal(false);
+  const [previewMode, setPreviewMode] = createSignal(false);
 
   // File tabs
   const [fileTabs, setFileTabs] = createSignal<FileTab[]>([]);
@@ -372,6 +378,126 @@ export default function FileViewer(props: FileViewerProps) {
     return activeFile()?.language ?? 'plaintext';
   }
 
+  const isMarkdown = () => currentLang() === 'markdown';
+
+  // ── Markdown preview rendering ──────────────────────────────────────────
+
+  // Signal for the final HTML — starts as parsed markdown, updated when highlights resolve
+  const [displayHtml, setDisplayHtml] = createSignal('');
+
+  const parsedMarkdownHtml = createMemo(() => {
+    if (!previewMode() || !isMarkdown()) return '';
+    const content = activeFile()?.content;
+    if (!content) return '';
+    const raw = marked.parse(content, { breaks: true, gfm: true });
+    // marked.parse can return string | Promise<string> — sync input returns string
+    return DOMPurify.sanitize(typeof raw === 'string' ? raw : '');
+  });
+
+  // Monotonic counter for highlight block IDs
+  let _hlCounter = 0;
+
+  // Highlight code blocks off the main thread after markdown is parsed
+  createEffect(() => {
+    const html = parsedMarkdownHtml();
+    if (!html) {
+      setDisplayHtml('');
+      return;
+    }
+
+    const template = document.createElement('template');
+    template.innerHTML = html;
+    const fragment = template.content;
+    const codeBlocks = fragment.querySelectorAll('pre code');
+
+    if (codeBlocks.length === 0) {
+      setDisplayHtml(html);
+      return;
+    }
+
+    let pendingCount = codeBlocks.length;
+
+    codeBlocks.forEach((codeEl, index) => {
+      const code = codeEl.textContent ?? '';
+      if (!code.trim()) {
+        pendingCount--;
+        if (pendingCount === 0) setDisplayHtml(template.innerHTML);
+        return;
+      }
+
+      let language: string | undefined;
+      for (const cls of codeEl.className.split(/\s+/)) {
+        if (cls.startsWith('language-')) {
+          language = cls.slice('language-'.length);
+          break;
+        }
+      }
+
+      const blockId = `fv-hl-${index}-${++_hlCounter}`;
+      highlightCode(blockId, code, language, (_id, highlighted) => {
+        codeEl.innerHTML = highlighted;
+        codeEl.classList.add('hljs');
+        pendingCount--;
+        if (pendingCount === 0) setDisplayHtml(template.innerHTML);
+      });
+    });
+
+    // Show un-highlighted markdown immediately while highlights are pending
+    setDisplayHtml(html);
+  });
+
+  // Post-render: copy buttons on <pre> blocks, external link handling
+  let previewRef: HTMLDivElement | undefined;
+
+  createEffect(() => {
+    void displayHtml();
+    if (!previewRef) return;
+    requestAnimationFrame(() => {
+      if (!previewRef) return;
+
+      // Copy buttons on <pre> blocks
+      previewRef.querySelectorAll('pre').forEach((pre) => {
+        if (pre.querySelector('.copy-btn')) return;
+        const btn = document.createElement('button');
+        btn.className = 'copy-btn';
+        btn.textContent = 'Copy';
+        pre.style.position = 'relative';
+        pre.addEventListener('mouseenter', () => { btn.style.opacity = '1'; });
+        pre.addEventListener('mouseleave', () => { btn.style.opacity = '0'; });
+        btn.addEventListener('click', () => {
+          const code = pre.querySelector('code')?.textContent ?? pre.textContent ?? '';
+          navigator.clipboard.writeText(code);
+          btn.textContent = 'Copied!';
+          setTimeout(() => { btn.textContent = 'Copy'; }, 1500);
+        });
+        pre.appendChild(btn);
+      });
+
+      // External links -> system browser
+      previewRef.querySelectorAll('a[href]').forEach((a) => {
+        if ((a as HTMLElement).dataset.extWired) return;
+        const href = a.getAttribute('href') ?? '';
+        if (href.startsWith('http://') || href.startsWith('https://')) {
+          (a as HTMLElement).dataset.extWired = '1';
+          a.addEventListener('click', (e) => {
+            e.preventDefault();
+            window.open(href, '_blank');
+          });
+        }
+      });
+    });
+  });
+
+  // Reset preview mode when switching to a non-markdown file
+  createEffect(
+    on(
+      () => activeFile()?.filePath,
+      () => {
+        if (!isMarkdown()) setPreviewMode(false);
+      },
+    ),
+  );
+
   // ── Lifecycle ────────────────────────────────────────────────────────────
 
   onMount(() => {
@@ -431,6 +557,13 @@ export default function FileViewer(props: FileViewerProps) {
       if (e.altKey && e.key === 'z') {
         e.preventDefault();
         setLineWrapping((v) => !v);
+        return;
+      }
+
+      // Cmd+Shift+P — toggle markdown preview
+      if (meta && e.shiftKey && e.key === 'p' && isMarkdown() && mode() === 'file') {
+        e.preventDefault();
+        setPreviewMode((v) => !v);
         return;
       }
 
@@ -505,6 +638,30 @@ export default function FileViewer(props: FileViewerProps) {
               Diffs ({diffTabs().length})
             </button>
           </Show>
+
+          {/* Markdown preview toggle — in tab bar for visibility */}
+          <Show when={isMarkdown()}>
+            <div class={styles.previewToggleGroup}>
+              <button
+                type="button"
+                class={styles.previewToggleBtn}
+                data-active={!previewMode()}
+                onClick={() => setPreviewMode(false)}
+                title="View source (Cmd+Shift+P)"
+              >
+                Source
+              </button>
+              <button
+                type="button"
+                class={styles.previewToggleBtn}
+                data-active={previewMode()}
+                onClick={() => setPreviewMode(true)}
+                title="Rendered preview (Cmd+Shift+P)"
+              >
+                Preview
+              </button>
+            </div>
+          </Show>
         </div>
       </Show>
 
@@ -569,17 +726,29 @@ export default function FileViewer(props: FileViewerProps) {
           </div>
         </Show>
 
-        {/* File view — CodeMirror editor (read + edit mode) */}
+        {/* File view — CodeMirror editor or markdown preview */}
         <Show when={!loading() && mode() === 'file' && activeFile()}>
-          <CodeMirrorEditor
-            content={activeFile()!.content}
-            language={langExtension()}
-            readOnly={!activeFile()!.editing}
-            lineWrapping={lineWrapping()}
-            theme={phantomThemeExtension}
-            onChange={handleContentChange}
-            class={styles.cmFillContainer}
-          />
+          <Show when={previewMode() && isMarkdown()} fallback={
+            <CodeMirrorEditor
+              content={activeFile()!.content}
+              language={langExtension()}
+              readOnly={!activeFile()!.editing}
+              lineWrapping={lineWrapping()}
+              theme={phantomThemeExtension}
+              onChange={handleContentChange}
+              class={styles.cmFillContainer}
+            />
+          }>
+            <div class={markdownStyles.previewContainer}>
+              <div class={markdownStyles.scrollArea}>
+                <div
+                  ref={previewRef}
+                  class={markdownStyles.markdownProse}
+                  innerHTML={displayHtml()}
+                />
+              </div>
+            </div>
+          </Show>
         </Show>
 
         {/* Diff view — CodeMirror merge */}

--- a/v2/frontend/src/components/panes/PaneContainer.tsx
+++ b/v2/frontend/src/components/panes/PaneContainer.tsx
@@ -1,7 +1,7 @@
 // Phantom — Individual pane wrapper with header + content
 // Author: Subash Karki
 
-import { Show, createSignal, lazy } from 'solid-js';
+import { Show, createSignal, lazy, ErrorBoundary } from 'solid-js';
 import { Suspense, Dynamic } from 'solid-js/web';
 import { Columns2, Rows2, X, Settings2 } from 'lucide-solid';
 import { Skeleton } from '@kobalte/core/skeleton';
@@ -9,6 +9,7 @@ import * as styles from '@/styles/panes.css';
 import { activeTab, setActivePaneInTab, splitPane, closePane, activePaneId, getPaneColor, tabs } from '@/core/panes/signals';
 import { getPaneComponent } from './PaneRegistry';
 import type { PaneLeaf } from '@/core/panes/types';
+import { vars } from '@/styles/theme.css';
 
 const TerminalSettings = lazy(() => import('./TerminalSettings'));
 
@@ -138,7 +139,20 @@ export function PaneContainer(props: PaneContainerProps) {
         <Show when={PaneComponent()} fallback={<PlaceholderContent />}>
           {(Comp) => (
             <Suspense fallback={<PlaceholderContent />}>
-              <Dynamic component={Comp()} paneId={paneId()} cwd={paneData()?.data?.cwd as string ?? ''} worktreeId={paneData()?.data?.worktreeId as string ?? ''} projectId={paneData()?.data?.projectId as string ?? ''} sessionId={paneData()?.data?.sessionId as string ?? ''} command={paneData()?.data?.command as string ?? ''} restore={!!paneData()?.data?.restore} filePath={paneData()?.data?.filePath as string ?? ''} workspaceId={paneData()?.data?.workspaceId as string ?? ''} isPlanFile={!!paneData()?.data?.isPlanFile} line={paneData()?.data?.line as number | undefined} column={paneData()?.data?.column as number | undefined} originalContent={paneData()?.data?.originalContent as string ?? ''} modifiedContent={paneData()?.data?.modifiedContent as string ?? ''} originalLabel={paneData()?.data?.originalLabel as string ?? ''} modifiedLabel={paneData()?.data?.modifiedLabel as string ?? ''} language={paneData()?.data?.language as string ?? ''} readOnly={!!paneData()?.data?.readOnly} noteId={paneData()?.data?.noteId as string ?? ''} />
+              <ErrorBoundary fallback={(err, reset) => {
+                console.error(`[ErrorBoundary:Pane:${paneType()}]`, err);
+                return (
+                  <div style={{ display: 'flex', 'flex-direction': 'column', 'align-items': 'center', 'justify-content': 'center', height: '100%', gap: vars.space.md, color: vars.color.textSecondary }}>
+                    <div style={{ 'font-family': vars.font.mono, 'font-size': vars.fontSize.sm }}>This pane crashed</div>
+                    <div style={{ 'font-family': vars.font.mono, 'font-size': vars.fontSize.xs, color: vars.color.textDisabled }}>{String(err)}</div>
+                    <button style={{ padding: `${vars.space.xs} ${vars.space.sm}`, 'border-radius': vars.radius.sm, background: vars.color.surfaceHover, color: vars.color.textPrimary, border: `1px solid ${vars.color.border}`, cursor: 'pointer', 'font-family': vars.font.body, 'font-size': vars.fontSize.xs }} onClick={() => reset()}>
+                      Retry
+                    </button>
+                  </div>
+                );
+              }}>
+                <Dynamic component={Comp()} paneId={paneId()} cwd={paneData()?.data?.cwd as string ?? ''} worktreeId={paneData()?.data?.worktreeId as string ?? ''} projectId={paneData()?.data?.projectId as string ?? ''} sessionId={paneData()?.data?.sessionId as string ?? ''} command={paneData()?.data?.command as string ?? ''} restore={!!paneData()?.data?.restore} filePath={paneData()?.data?.filePath as string ?? ''} workspaceId={paneData()?.data?.workspaceId as string ?? ''} isPlanFile={!!paneData()?.data?.isPlanFile} line={paneData()?.data?.line as number | undefined} column={paneData()?.data?.column as number | undefined} originalContent={paneData()?.data?.originalContent as string ?? ''} modifiedContent={paneData()?.data?.modifiedContent as string ?? ''} originalLabel={paneData()?.data?.originalLabel as string ?? ''} modifiedLabel={paneData()?.data?.modifiedLabel as string ?? ''} language={paneData()?.data?.language as string ?? ''} readOnly={!!paneData()?.data?.readOnly} noteId={paneData()?.data?.noteId as string ?? ''} />
+              </ErrorBoundary>
             </Suspense>
           )}
         </Show>

--- a/v2/frontend/src/components/panes/WorktreeHome.tsx
+++ b/v2/frontend/src/components/panes/WorktreeHome.tsx
@@ -22,6 +22,7 @@ import { showToast, showWarningToast } from '@/shared/Toast/Toast';
 import { Tip } from '@/shared/Tip/Tip';
 import { vars } from '@/styles/theme.css';
 import { formatCost, formatDuration } from '@/core/signals/journal';
+import { timeAgo } from '@/utils/format';
 import { openRecipePicker, recipePickerOpen } from '@/core/signals/recipes';
 import { ProjectNotes } from '@/shared/ProjectNotes';
 import type { RepoStatus, PrStatus as PrStatusType, CiRun, CheckAnnotation, FailedStep, JournalEntry, EnrichedRecipe, RepoMergeConfig, Reviewer, MergeMethod } from '@/core/types';
@@ -69,17 +70,6 @@ function RecentSessions(props: { repoPath: string | null }) {
     });
     onCleanup(() => { cancelled = true; });
   }));
-
-  const timeAgo = (epochSecs: number | null): string => {
-    if (!epochSecs) return '';
-    const diffMins = Math.round((Date.now() / 1000 - epochSecs) / 60);
-    if (diffMins < 1) return 'just now';
-    if (diffMins < 60) return `${diffMins}m ago`;
-    const hrs = Math.floor(diffMins / 60);
-    if (hrs < 24) return `${hrs}h ago`;
-    const days = Math.floor(hrs / 24);
-    return `${days}d ago`;
-  };
 
   const statusColor = (status: string | null): string => {
     const st = (status ?? '').toLowerCase();

--- a/v2/frontend/src/components/sidebar/WorkflowsSection.tsx
+++ b/v2/frontend/src/components/sidebar/WorkflowsSection.tsx
@@ -8,6 +8,7 @@ import { activeWorktreeId } from '@/core/signals/app';
 import type { Workflow, WorkflowRun } from '@/core/types';
 import { dispatchWorkflow, rerunWorkflow, cancelWorkflowRun } from '@/core/bindings/git';
 import { openURL } from '@/core/bindings/shell';
+import { timeAgo } from '@/utils/format';
 import * as s from '@/styles/right-sidebar.css';
 import { iconSuccess, iconDanger, iconWarning, iconMuted } from '@/styles/utilities.css';
 
@@ -18,16 +19,6 @@ interface WorkflowsSectionProps {
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
-
-function timeAgo(dateStr: string): string {
-  const now = Date.now();
-  const then = new Date(dateStr).getTime();
-  const diff = Math.floor((now - then) / 1000);
-  if (diff < 60) return 'just now';
-  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
-  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
-  return `${Math.floor(diff / 86400)}d ago`;
-}
 
 function getStatusIcon(status: string, conclusion: string): JSX.Element {
   if (conclusion === 'success') return <CheckCircle size={13} class={iconSuccess} />;

--- a/v2/frontend/src/core/bindings/_app.ts
+++ b/v2/frontend/src/core/bindings/_app.ts
@@ -1,0 +1,3 @@
+// Author: Subash Karki
+export const App = () => (window as any).go?.['app']?.App;
+export const ComposerBindings = () => (window as any).go?.['composer']?.Bindings;

--- a/v2/frontend/src/core/bindings/ai-insight.ts
+++ b/v2/frontend/src/core/bindings/ai-insight.ts
@@ -2,8 +2,7 @@
 // Author: Subash Karki
 
 import { normalize } from './_normalize';
-
-const App = () => (window as any).go?.['app']?.App;
+import { App } from './_app';
 
 // ── Types ─────────────────────────────────────────────────────────────────
 

--- a/v2/frontend/src/core/bindings/applog.ts
+++ b/v2/frontend/src/core/bindings/applog.ts
@@ -1,6 +1,6 @@
 // Author: Subash Karki
 
-const App = () => (window as any).go?.['app']?.App;
+import { App } from './_app';
 
 export async function getRecentAppLogs(maxLines = 50): Promise<string[]> {
   try {

--- a/v2/frontend/src/core/bindings/byok.ts
+++ b/v2/frontend/src/core/bindings/byok.ts
@@ -1,7 +1,7 @@
 // Phantom — BYOK bindings (user-supplied Anthropic API key in Keychain)
 // Author: Subash Karki
 
-const App = () => (window as any).go?.['app']?.App;
+import { App } from './_app';
 
 export async function setAnthropicApiKey(key: string): Promise<{ ok: boolean; error?: string }> {
   try {

--- a/v2/frontend/src/core/bindings/composer.ts
+++ b/v2/frontend/src/core/bindings/composer.ts
@@ -2,9 +2,7 @@
 // Author: Subash Karki
 
 import { normalize } from './_normalize';
-
-const App = () => (window as any).go?.['app']?.App;
-const V2 = () => (window as any).go?.['composer']?.Bindings;
+import { App, ComposerBindings as V2 } from './_app';
 
 export interface ComposerMention {
   path: string;

--- a/v2/frontend/src/core/bindings/cost.ts
+++ b/v2/frontend/src/core/bindings/cost.ts
@@ -2,8 +2,7 @@
 // Author: Subash Karki
 
 import { normalize } from './_normalize';
-
-const App = () => (window as any).go?.['app']?.App;
+import { App } from './_app';
 
 export interface DailyCostReport {
   date: string;

--- a/v2/frontend/src/core/bindings/deps.ts
+++ b/v2/frontend/src/core/bindings/deps.ts
@@ -3,8 +3,7 @@
 // Author: Subash Karki
 
 import type { HealthStatus } from '../types/provider';
-
-const App = () => (window as any).go?.['app']?.App;
+import { App } from './_app';
 
 export async function recheckProviderHealth(name: string): Promise<HealthStatus | null> {
   try {

--- a/v2/frontend/src/core/bindings/digest.ts
+++ b/v2/frontend/src/core/bindings/digest.ts
@@ -2,8 +2,7 @@
 // Author: Subash Karki
 
 import { normalize } from './_normalize';
-
-const App = () => (window as any).go?.['app']?.App;
+import { App } from './_app';
 
 export interface DigestSummary {
   date: string;

--- a/v2/frontend/src/core/bindings/editor.ts
+++ b/v2/frontend/src/core/bindings/editor.ts
@@ -3,8 +3,7 @@
 
 import { showErrorToast } from '../../shared/Toast/Toast';
 import type { BlameLine } from '../types';
-
-const App = () => (window as any).go?.['app']?.App;
+import { App } from './_app';
 
 /**
  * Read file contents from a workspace.

--- a/v2/frontend/src/core/bindings/evolution.ts
+++ b/v2/frontend/src/core/bindings/evolution.ts
@@ -5,8 +5,7 @@
 // Author: Subash Karki
 
 import { normalize } from './_normalize';
-
-const App = () => (window as any).go?.['app']?.App;
+import { App } from './_app';
 
 // ── Types ─────────────────────────────────────────────────────────────────
 

--- a/v2/frontend/src/core/bindings/git.ts
+++ b/v2/frontend/src/core/bindings/git.ts
@@ -2,8 +2,7 @@
 
 import type { Workspace, RepoStatus, FileStatus, CommitInfo, FileEntry, PrStatus, CiRun, CheckAnnotation, RepoMergeConfig, MergeMethod } from '../types';
 import { normalize } from './_normalize';
-
-const App = () => (window as any).go?.['app']?.App;
+import { App } from './_app';
 
 export async function getProjectBranches(projectId: string): Promise<string[]> {
   try {

--- a/v2/frontend/src/core/bindings/health.ts
+++ b/v2/frontend/src/core/bindings/health.ts
@@ -1,8 +1,7 @@
 // Author: Subash Karki
 
 import type { HealthResponse } from '../types';
-
-const App = () => (window as any).go?.['app']?.App;
+import { App } from './_app';
 
 export async function healthCheck(): Promise<HealthResponse | null> {
   try {

--- a/v2/frontend/src/core/bindings/journal.ts
+++ b/v2/frontend/src/core/bindings/journal.ts
@@ -3,8 +3,7 @@
 
 import type { JournalEntry, DailyStats, DailyJournalEntry } from '../types';
 import { normalize } from './_normalize';
-
-const App = () => (window as any).go?.['app']?.App;
+import { App } from './_app';
 
 // ── Legacy session-based journal ─────────────────────────────────────────────
 

--- a/v2/frontend/src/core/bindings/mcp.ts
+++ b/v2/frontend/src/core/bindings/mcp.ts
@@ -2,8 +2,7 @@
 // Author: Subash Karki
 
 import { normalize } from './_normalize';
-
-const App = () => (window as any).go?.['app']?.App;
+import { App } from './_app';
 
 export interface MCPServer {
   name: string;

--- a/v2/frontend/src/core/bindings/native-terminal.ts
+++ b/v2/frontend/src/core/bindings/native-terminal.ts
@@ -1,6 +1,6 @@
 // Author: Subash Karki
 
-const App = () => (window as any).go?.['app']?.App;
+import { App } from './_app';
 
 export async function nativeTerminalIsEnabled(): Promise<boolean> {
   try {

--- a/v2/frontend/src/core/bindings/notes.ts
+++ b/v2/frontend/src/core/bindings/notes.ts
@@ -2,8 +2,7 @@
 
 import type { ProjectNote } from '../types';
 import { normalize } from './_normalize';
-
-const App = () => (window as any).go?.['app']?.App;
+import { App } from './_app';
 
 export async function listProjectNotes(projectId: string): Promise<ProjectNote[]> {
   try {

--- a/v2/frontend/src/core/bindings/perf.ts
+++ b/v2/frontend/src/core/bindings/perf.ts
@@ -1,6 +1,6 @@
 // Author: Subash Karki
 
-const App = () => (window as any).go?.['app']?.App;
+import { App } from './_app';
 
 export interface PerfSnapshot {
   count: number;

--- a/v2/frontend/src/core/bindings/plans.ts
+++ b/v2/frontend/src/core/bindings/plans.ts
@@ -3,8 +3,7 @@
 // Author: Subash Karki
 
 import { normalize } from './_normalize';
-
-const App = () => (window as any).go?.['app']?.App;
+import { App } from './_app';
 
 export interface PlanFile {
   filePath: string;

--- a/v2/frontend/src/core/bindings/playground.ts
+++ b/v2/frontend/src/core/bindings/playground.ts
@@ -2,8 +2,7 @@
 // Author: Subash Karki
 
 import { normalize } from './_normalize';
-
-const App = () => (window as any).go?.['app']?.App;
+import { App } from './_app';
 
 // ── Types ─────────────────────────────────────────────────────────────────
 

--- a/v2/frontend/src/core/bindings/preferences.ts
+++ b/v2/frontend/src/core/bindings/preferences.ts
@@ -1,6 +1,6 @@
 // Author: Subash Karki
 
-const App = () => (window as any).go?.['app']?.App;
+import { App } from './_app';
 
 export async function getPreference(key: string): Promise<string> {
   try {

--- a/v2/frontend/src/core/bindings/projects.ts
+++ b/v2/frontend/src/core/bindings/projects.ts
@@ -9,8 +9,7 @@ interface ProjectProfile {
   framework: string | null;
 }
 import { normalize } from './_normalize';
-
-const App = () => (window as any).go?.['app']?.App;
+import { App } from './_app';
 
 export async function getProjects(): Promise<Project[]> {
   try {

--- a/v2/frontend/src/core/bindings/providers.ts
+++ b/v2/frontend/src/core/bindings/providers.ts
@@ -2,8 +2,7 @@
 // Author: Subash Karki
 
 import type { ProviderInfo, HealthStatus } from '../types/provider';
-
-const App = () => (window as any).go?.['app']?.App;
+import { App } from './_app';
 
 export async function getProviders(): Promise<ProviderInfo[]> {
   try {

--- a/v2/frontend/src/core/bindings/recipes.ts
+++ b/v2/frontend/src/core/bindings/recipes.ts
@@ -2,8 +2,7 @@
 
 import type { EnrichedRecipe } from '../types';
 import { normalize } from './_normalize';
-
-const App = () => (window as any).go?.['app']?.App;
+import { App } from './_app';
 
 /**
  * Get all recipes (auto-detected + custom) for a project, with favorite status.

--- a/v2/frontend/src/core/bindings/search.ts
+++ b/v2/frontend/src/core/bindings/search.ts
@@ -9,7 +9,7 @@ export interface SearchResult {
   matchEnd: number;
 }
 
-const App = () => (window as any).go?.['app']?.App;
+import { App } from './_app';
 
 /**
  * Search file contents within a workspace.

--- a/v2/frontend/src/core/bindings/sessions.ts
+++ b/v2/frontend/src/core/bindings/sessions.ts
@@ -2,8 +2,7 @@
 
 import type { Session, Task, ActivityLog, SessionState } from '../types';
 import { normalize } from './_normalize';
-
-const App = () => (window as any).go?.['app']?.App;
+import { App } from './_app';
 
 export async function getSessions(): Promise<Session[]> {
   try {

--- a/v2/frontend/src/core/bindings/shell.ts
+++ b/v2/frontend/src/core/bindings/shell.ts
@@ -1,7 +1,7 @@
 // Phantom — Shell operation bindings (Finder, default app)
 // Author: Subash Karki
 
-const App = () => (window as any).go?.['app']?.App;
+import { App } from './_app';
 
 export async function revealInFinder(path: string): Promise<boolean> {
   try { await App()?.RevealInFinder(path); return true; } catch { return false; }

--- a/v2/frontend/src/core/bindings/system.ts
+++ b/v2/frontend/src/core/bindings/system.ts
@@ -1,7 +1,7 @@
 // Phantom — system-level Wails bindings (factory reset, etc.)
 // Author: Subash Karki
 
-const App = () => (window as any).go?.['app']?.App;
+import { App } from './_app';
 
 export async function factoryResetLocalData(confirmation: string): Promise<string> {
   try {

--- a/v2/frontend/src/core/bindings/tasks.ts
+++ b/v2/frontend/src/core/bindings/tasks.ts
@@ -1,8 +1,7 @@
 // Author: Subash Karki
 
 import { normalize } from './_normalize';
-
-const App = () => (window as any).go?.['app']?.App;
+import { App } from './_app';
 
 export interface TaskItem {
   id: string;

--- a/v2/frontend/src/core/bindings/terminal.ts
+++ b/v2/frontend/src/core/bindings/terminal.ts
@@ -1,6 +1,6 @@
 // Author: Subash Karki
 
-const App = () => (window as any).go?.['app']?.App;
+import { App } from './_app';
 
 export async function createTerminal(
   id: string,

--- a/v2/frontend/src/core/composer/reducers.ts
+++ b/v2/frontend/src/core/composer/reducers.ts
@@ -26,6 +26,13 @@ type SetState = (fn: (state: ComposerState) => void) => void
 let msgCounter = 0
 const nextMsgId = () => 'msg_' + ++msgCounter
 
+const MAX_MESSAGES = 500
+function trimMessages(messages: Message[]) {
+  if (messages.length > MAX_MESSAGES) {
+    messages.splice(0, messages.length - MAX_MESSAGES)
+  }
+}
+
 /** Reset counter — exposed for tests only. */
 export const resetMsgCounter = () => {
   msgCounter = 0
@@ -120,6 +127,7 @@ export const reduceAssistantDelta = (
         s.strategy = null
       }
       s.messages.push(msg)
+      trimMessages(s.messages)
       s.streaming = { msgId: id, blockIdx: 0 }
     })
   } else {
@@ -466,6 +474,7 @@ export const reduceAssistantMessage = (
         s.strategy = null
       }
       s.messages.push(newMsg)
+      trimMessages(s.messages)
       if (!isFinal) {
         s.streaming = { msgId: id, blockIdx: 0 }
       } else {
@@ -604,6 +613,7 @@ const handleStreamMessageStart = (setState: SetState, state: ComposerState) => {
       s.strategy = null
     }
     s.messages.push(msg)
+    trimMessages(s.messages)
     s.streaming = { msgId: id, blockIdx: 0 }
   })
 }
@@ -634,6 +644,7 @@ const handleStreamBlockStart = (
         s.strategy = null
       }
       s.messages.push(msg)
+      trimMessages(s.messages)
       s.streaming = { msgId: id, blockIdx: 0 }
     })
     // Re-find after creation — the state reference is stale but we need the
@@ -730,6 +741,7 @@ const handleStreamDelta = (
         s.strategy = null
       }
       s.messages.push(msg)
+      trimMessages(s.messages)
       s.streaming = { msgId: id, blockIdx: 0 }
     })
     return
@@ -1081,6 +1093,7 @@ export const reduceError = (
       timestamp: Date.now(),
     }
     s.messages.push(msg)
+    trimMessages(s.messages)
     s.streaming = null
   })
 }
@@ -1170,6 +1183,7 @@ export const reduceCompactBoundary = (
       timestamp: Date.now(),
     }
     s.messages.push(msg)
+    trimMessages(s.messages)
   })
 }
 

--- a/v2/frontend/src/core/composer/store.ts
+++ b/v2/frontend/src/core/composer/store.ts
@@ -129,6 +129,12 @@ export const switchComposerWorkspace = (worktreeId: string): void => {
       stores: new Map(sessionStores),
       activeId: activeSessionId(),
     })
+
+    const MAX_CACHED = 5
+    if (sessionCache.size > MAX_CACHED) {
+      const oldest = sessionCache.keys().next().value
+      if (oldest && oldest !== worktreeId) sessionCache.delete(oldest)
+    }
   }
   previousComposerWorktreeId = worktreeId
 
@@ -137,6 +143,10 @@ export const switchComposerWorkspace = (worktreeId: string): void => {
 
   const cached = sessionCache.get(worktreeId)
   if (cached) {
+    // Refresh LRU recency by re-inserting
+    sessionCache.delete(worktreeId)
+    sessionCache.set(worktreeId, cached)
+
     // Restore the saved session stores into the live map
     for (const [id, tuple] of cached.stores) {
       sessionStores.set(id, tuple)

--- a/v2/frontend/src/core/signals/journal.ts
+++ b/v2/frontend/src/core/signals/journal.ts
@@ -76,11 +76,8 @@ export const bootstrapJournal = async (): Promise<void> => {
   ]);
 };
 
-// Helper: format cost from microdollars
-export const formatCost = (micros: number | null): string => {
-  if (!micros) return '$0.00';
-  return `$${(micros / 1_000_000).toFixed(2)}`;
-};
+// Re-export from canonical format utils
+export { formatCostMicros as formatCost } from '../../utils/format';
 
 // Helper: normalize timestamp to seconds (handles both ms and s)
 const toSecs = (t: number): number => (t > 1e12 ? Math.floor(t / 1000) : t);

--- a/v2/frontend/src/core/signals/live-sessions.ts
+++ b/v2/frontend/src/core/signals/live-sessions.ts
@@ -6,6 +6,7 @@ import { worktreeMap } from './worktrees';
 import { projects } from './projects';
 import { listTerminals, type TerminalInfo } from '../bindings/terminal';
 import type { Session } from '../types/index';
+import { windowVisible } from './visibility';
 
 export interface LiveWorktree {
   worktreeId: string;
@@ -24,6 +25,7 @@ let polling: ReturnType<typeof setInterval> | undefined;
 export function bootstrapLiveSessions(): void {
   listTerminals().then(setActiveTerminals);
   polling = setInterval(() => {
+    if (!windowVisible()) return;
     listTerminals().then(setActiveTerminals);
   }, 3_000);
 }

--- a/v2/frontend/src/core/signals/sessions.ts
+++ b/v2/frontend/src/core/signals/sessions.ts
@@ -5,6 +5,7 @@ import { createSignal, createMemo } from 'solid-js';
 import type { Session } from '../types';
 import { getSessions, getSession, forkSession as forkSessionBinding } from '../bindings';
 import { onWailsEvent } from '../events';
+import { windowVisible } from './visibility';
 
 // ── Event payload types (Go backend sends these, NOT full Session objects) ──
 
@@ -72,6 +73,7 @@ export function bootstrapSessions(): void {
 
   // Poll every 15s as fallback when Wails event bridge is unavailable
   setInterval(() => {
+    if (!windowVisible()) return;
     getSessions().then((data) => setSessions(data));
   }, 15_000);
 

--- a/v2/frontend/src/core/signals/visibility.ts
+++ b/v2/frontend/src/core/signals/visibility.ts
@@ -1,0 +1,4 @@
+// Author: Subash Karki
+import { createSignal } from 'solid-js';
+
+export const [windowVisible, setWindowVisible] = createSignal(true);

--- a/v2/frontend/src/core/signals/worktrees.ts
+++ b/v2/frontend/src/core/signals/worktrees.ts
@@ -10,6 +10,7 @@ import { setPref, loadPref } from './preferences';
 import { clearWorktreeCache } from '../panes/signals';
 import { pushMru, initMru, pruneMru } from './worktree-mru';
 import type { Workspace, WorktreeStatus } from '../types';
+import { windowVisible } from './visibility';
 
 // Worktree data per project (keyed by project id)
 const [worktreeMap, setWorktreeMap] = createSignal<Record<string, Workspace[]>>({});
@@ -150,6 +151,7 @@ export async function bootstrapWorktrees(): Promise<void> {
   // event below covers the common case in real time.
   refreshAllWorktreeStatuses();
   setInterval(() => {
+    if (!windowVisible()) return;
     refreshAllWorktreeStatuses();
   }, 15_000);
 

--- a/v2/frontend/src/core/terminal/addons/shellIntegration.ts
+++ b/v2/frontend/src/core/terminal/addons/shellIntegration.ts
@@ -325,6 +325,16 @@ function handleCommandFinished(state: SessionState, rest: string): void {
   cur.endMarker = state.terminal?.registerMarker(0) ?? undefined;
 
   state.commands.push(cur);
+
+  const MAX_COMMANDS = 200;
+  while (state.commands.length > MAX_COMMANDS) {
+    const old = state.commands.shift()!;
+    old.promptStartMarker?.dispose();
+    old.commandStartMarker?.dispose();
+    old.executedMarker?.dispose();
+    old.endMarker?.dispose();
+  }
+
   state.current = null;
   emitFinished(state, cur);
 }

--- a/v2/frontend/src/screens/boot/scan-system.ts
+++ b/v2/frontend/src/screens/boot/scan-system.ts
@@ -34,7 +34,7 @@ interface BootScanData {
   agents?: AgentStatus[];
 }
 
-const App = () => (window as any).go?.['app']?.App;
+import { App } from '../../core/bindings/_app';
 
 /** Short display names for known agents — keeps the summary row compact. */
 const AGENT_SHORT_NAMES: Record<string, string> = {

--- a/v2/frontend/src/screens/onboarding/phases/AIEngineConsent.tsx
+++ b/v2/frontend/src/screens/onboarding/phases/AIEngineConsent.tsx
@@ -21,7 +21,7 @@ interface MCPStatus {
   error?: string;
 }
 
-const App = () => (window as any).go?.['app']?.App;
+import { App } from '../../../core/bindings/_app';
 
 async function getMCPStatus(): Promise<MCPStatus> {
   try {

--- a/v2/frontend/src/screens/onboarding/phases/BootTerminal.tsx
+++ b/v2/frontend/src/screens/onboarding/phases/BootTerminal.tsx
@@ -10,7 +10,7 @@ import type { BootLine, LineStyle, BootScanData } from '../config/types';
 import { BootRings } from './BootRings';
 import { PhantomMark } from '../../../shared/PhantomMark/PhantomMark';
 
-const App = () => (window as any).go?.['app']?.App;
+import { App } from '../../../core/bindings/_app';
 
 interface BootTerminalProps {
   onBootComplete: (scan?: BootScanData) => void;

--- a/v2/frontend/src/screens/onboarding/phases/DepsCheck.tsx
+++ b/v2/frontend/src/screens/onboarding/phases/DepsCheck.tsx
@@ -18,7 +18,7 @@ import { InstallGuide } from './InstallGuide';
 import * as styles from '../styles/deps-check.css';
 import * as phaseStyles from '../styles/phases.css';
 
-const App = () => (window as any).go?.['app']?.App;
+import { App } from '../../../core/bindings/_app';
 
 interface DepsCheckProps {
   scan?: BootScanData;

--- a/v2/frontend/src/screens/system/AnalyticsPanel.tsx
+++ b/v2/frontend/src/screens/system/AnalyticsPanel.tsx
@@ -4,6 +4,7 @@
 import { createSignal, createMemo, onMount, Show, For } from 'solid-js';
 import { getDailyStatsRange, getRecentSessions } from '@/core/bindings/journal';
 import { formatCost } from '@/core/signals/journal';
+import { formatTokens } from '@/utils/format';
 import { BarChart } from '@/shared/BarChart/BarChart';
 import * as styles from './AnalyticsPanel.css';
 
@@ -18,12 +19,6 @@ const PROVIDER_COLORS: Record<string, string> = {
 };
 
 const DAY_ABBREVS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
-
-const formatTokens = (count: number): string => {
-  if (count >= 1_000_000) return `${(count / 1_000_000).toFixed(1)}M`;
-  if (count >= 1_000) return `${(count / 1_000).toFixed(0)}K`;
-  return String(count);
-};
 
 const formatAvgDuration = (totalSecs: number, sessionCount: number): string => {
   if (sessionCount === 0 || totalSecs <= 0) return '0m';

--- a/v2/frontend/src/screens/system/ResourceMonitorPanel.tsx
+++ b/v2/frontend/src/screens/system/ResourceMonitorPanel.tsx
@@ -16,6 +16,7 @@ import { listTerminals, destroyTerminal } from '@/core/bindings/terminal';
 import { healthCheck } from '@/core/bindings/health';
 import { addTabWithData } from '@/core/panes/signals';
 import { activeProvider, activeProviderLabel } from '@/core/signals/active-provider';
+import { formatTokens } from '@/utils/format';
 import * as styles from './ResourceMonitorPanel.css';
 
 import type { JSX } from 'solid-js';
@@ -27,12 +28,6 @@ const PROVIDER_COLORS: Record<string, string> = {
   claude: '#a855f7',
   codex: '#22c55e',
   gemini: '#3b82f6',
-};
-
-const formatTokens = (count: number): string => {
-  if (count >= 1_000_000) return `${(count / 1_000_000).toFixed(1)}M`;
-  if (count >= 1_000) return `${(count / 1_000).toFixed(0)}K`;
-  return String(count);
 };
 
 const formatDuration = (startedAtSecs: number, nowMs: number): string => {

--- a/v2/frontend/src/shared/DigestDrawer/DigestDrawer.tsx
+++ b/v2/frontend/src/shared/DigestDrawer/DigestDrawer.tsx
@@ -6,19 +6,8 @@ import { For, Show, createEffect, createMemo } from 'solid-js';
 import { RefreshCw, ChevronLeft, ChevronRight } from 'lucide-solid';
 import { PhantomDrawer } from '../PhantomDrawer/PhantomDrawer';
 import { digestOpen, closeDigest, digestData, digestLoading, loadDigest, costReport, digestDate, goToPrevDay, goToNextDay, goToToday, isToday } from '@/core/signals/digest';
+import { formatTokens, formatCostUsd } from '@/utils/format';
 import * as styles from './DigestDrawer.css';
-
-function formatTokens(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${Math.round(n / 1_000)}k`;
-  return String(n);
-}
-
-function formatCost(cost: number): string {
-  if (cost === 0) return '$0.00';
-  if (cost < 0.01) return `$${cost.toFixed(4)}`;
-  return `$${cost.toFixed(2)}`;
-}
 
 function formatPct(rate: number): string {
   return `${Math.round(rate * 100)}%`;
@@ -69,7 +58,7 @@ function CostBreakdown() {
                     <div class={styles.costBarTrack}>
                       <div class={styles.costBarFill} style={{ width: `${pct}%` }} />
                     </div>
-                    <span class={styles.costBarValue}>{formatCost(cost)}</span>
+                    <span class={styles.costBarValue}>{formatCostUsd(cost)}</span>
                   </div>
                 );
               }}
@@ -190,7 +179,7 @@ export function DigestDrawer() {
                 </div>
 
                 <div class={styles.statRow}>
-                  <span class={styles.statValue}>{formatCost(data().estimatedCost)}</span>
+                  <span class={styles.statValue}>{formatCostUsd(data().estimatedCost)}</span>
                   <span class={styles.statLabel}>estimated cost</span>
                 </div>
 

--- a/v2/frontend/src/shared/ProjectNotes/CreateNoteDialog.tsx
+++ b/v2/frontend/src/shared/ProjectNotes/CreateNoteDialog.tsx
@@ -6,18 +6,12 @@ import { PhantomModal, phantomModalStyles } from '@/shared/PhantomModal/PhantomM
 import { addNote } from '@/core/signals/notes';
 import { buttonRecipe } from '@/styles/recipes.css';
 import { vars } from '@/styles/theme.css';
+import { NOTE_TYPES } from '@/utils/note-types';
 
 interface CreateNoteDialogProps {
   open: () => boolean;
   onClose: () => void;
 }
-
-const NOTE_TYPES = [
-  { value: 'todo', label: 'Todo', color: '#f59e0b' },
-  { value: 'idea', label: 'Idea', color: '#3b82f6' },
-  { value: 'bug', label: 'Bug', color: '#ef4444' },
-  { value: 'note', label: 'Note', color: '#56CCFF' },
-] as const;
 
 type NoteType = (typeof NOTE_TYPES)[number]['value'];
 

--- a/v2/frontend/src/shared/ProjectNotes/NoteCard.tsx
+++ b/v2/frontend/src/shared/ProjectNotes/NoteCard.tsx
@@ -15,17 +15,9 @@ import {
   contextMenuItemDanger,
   contextMenuSeparator,
 } from '@/styles/sidebar.css';
+import { NOTE_COLORS } from '@/utils/note-types';
 import * as styles from './NoteCard.css';
 import type { ProjectNote } from '@/core/types';
-
-// ── Color map ───────────────────────────────────────────────────────────────
-
-const NOTE_COLORS: Record<string, string> = {
-  todo: '#f59e0b',
-  idea: '#3b82f6',
-  bug: '#ef4444',
-  note: '', // filled at render time with accent CSS var
-};
 
 // ── Markdown renderer ───────────────────────────────────────────────────────
 

--- a/v2/frontend/src/shared/StickyNotesOverlay/NotesDrawerCard.tsx
+++ b/v2/frontend/src/shared/StickyNotesOverlay/NotesDrawerCard.tsx
@@ -14,15 +14,9 @@ import {
   contextMenuItemDanger,
   contextMenuSeparator,
 } from '@/styles/sidebar.css';
+import { NOTE_COLORS } from '@/utils/note-types';
 import * as styles from './StickyNotesOverlay.css';
 import type { ProjectNote } from '@/core/types';
-
-const NOTE_COLORS: Record<string, string> = {
-  todo: '#f59e0b',
-  idea: '#3b82f6',
-  bug: '#ef4444',
-  note: '#00d4ff',
-};
 
 interface NotesDrawerCardProps {
   note: ProjectNote;

--- a/v2/frontend/src/shared/TipTapEditor/TipTapEditor.tsx
+++ b/v2/frontend/src/shared/TipTapEditor/TipTapEditor.tsx
@@ -177,11 +177,13 @@ export function TipTapEditor(props: TipTapEditorProps) {
 			style={props.fontSize ? { 'font-size': `${props.fontSize}px` } : undefined}
 		>
 			<Show when={props.toolbar !== false}>
-				<div class={styles.editorToolbar}>
+				<div class={styles.editorToolbar} role="toolbar" aria-label="Text formatting">
 					{/* Inline formatting */}
 					<button
 						class={btnClass(format().bold)}
 						title="Bold"
+						aria-label="Bold"
+						aria-pressed={format().bold}
 						onMouseDown={run(() => editor()?.chain().focus().toggleBold().run())}
 					>
 						<Bold size={15} />
@@ -189,6 +191,8 @@ export function TipTapEditor(props: TipTapEditorProps) {
 					<button
 						class={btnClass(format().italic)}
 						title="Italic"
+						aria-label="Italic"
+						aria-pressed={format().italic}
 						onMouseDown={run(() => editor()?.chain().focus().toggleItalic().run())}
 					>
 						<Italic size={15} />
@@ -196,6 +200,8 @@ export function TipTapEditor(props: TipTapEditorProps) {
 					<button
 						class={btnClass(format().strike)}
 						title="Strikethrough"
+						aria-label="Strikethrough"
+						aria-pressed={format().strike}
 						onMouseDown={run(() => editor()?.chain().focus().toggleStrike().run())}
 					>
 						<Strikethrough size={15} />
@@ -203,6 +209,8 @@ export function TipTapEditor(props: TipTapEditorProps) {
 					<button
 						class={btnClass(format().code)}
 						title="Inline Code"
+						aria-label="Code"
+						aria-pressed={format().code}
 						onMouseDown={run(() => editor()?.chain().focus().toggleCode().run())}
 					>
 						<Code size={15} />
@@ -214,6 +222,8 @@ export function TipTapEditor(props: TipTapEditorProps) {
 					<button
 						class={btnClass(format().heading1)}
 						title="Heading 1"
+						aria-label="Heading 1"
+						aria-pressed={format().heading1}
 						onMouseDown={run(() => editor()?.chain().focus().toggleHeading({ level: 1 }).run())}
 					>
 						<Heading1 size={15} />
@@ -221,6 +231,8 @@ export function TipTapEditor(props: TipTapEditorProps) {
 					<button
 						class={btnClass(format().heading2)}
 						title="Heading 2"
+						aria-label="Heading 2"
+						aria-pressed={format().heading2}
 						onMouseDown={run(() => editor()?.chain().focus().toggleHeading({ level: 2 }).run())}
 					>
 						<Heading2 size={15} />
@@ -228,6 +240,8 @@ export function TipTapEditor(props: TipTapEditorProps) {
 					<button
 						class={btnClass(format().heading3)}
 						title="Heading 3"
+						aria-label="Heading 3"
+						aria-pressed={format().heading3}
 						onMouseDown={run(() => editor()?.chain().focus().toggleHeading({ level: 3 }).run())}
 					>
 						<Heading3 size={15} />
@@ -239,6 +253,8 @@ export function TipTapEditor(props: TipTapEditorProps) {
 					<button
 						class={btnClass(format().bulletList)}
 						title="Bullet List"
+						aria-label="Bullet list"
+						aria-pressed={format().bulletList}
 						onMouseDown={run(() => editor()?.chain().focus().toggleBulletList().run())}
 					>
 						<List size={15} />
@@ -246,6 +262,8 @@ export function TipTapEditor(props: TipTapEditorProps) {
 					<button
 						class={btnClass(format().orderedList)}
 						title="Ordered List"
+						aria-label="Ordered list"
+						aria-pressed={format().orderedList}
 						onMouseDown={run(() => editor()?.chain().focus().toggleOrderedList().run())}
 					>
 						<ListOrdered size={15} />
@@ -253,6 +271,8 @@ export function TipTapEditor(props: TipTapEditorProps) {
 					<button
 						class={btnClass(format().taskList)}
 						title="Task List"
+						aria-label="Task list"
+						aria-pressed={format().taskList}
 						onMouseDown={run(() => editor()?.chain().focus().toggleTaskList().run())}
 					>
 						<CheckSquare size={15} />
@@ -264,6 +284,8 @@ export function TipTapEditor(props: TipTapEditorProps) {
 					<button
 						class={btnClass(format().blockquote)}
 						title="Blockquote"
+						aria-label="Blockquote"
+						aria-pressed={format().blockquote}
 						onMouseDown={run(() => editor()?.chain().focus().toggleBlockquote().run())}
 					>
 						<Quote size={15} />
@@ -271,6 +293,8 @@ export function TipTapEditor(props: TipTapEditorProps) {
 					<button
 						class={btnClass(format().codeBlock)}
 						title="Code Block"
+						aria-label="Code block"
+						aria-pressed={format().codeBlock}
 						onMouseDown={run(() => editor()?.chain().focus().toggleCodeBlock().run())}
 					>
 						<FileCode size={15} />
@@ -278,6 +302,7 @@ export function TipTapEditor(props: TipTapEditorProps) {
 					<button
 						class={styles.toolbarButton}
 						title="Horizontal Rule"
+						aria-label="Horizontal rule"
 						onMouseDown={run(() => editor()?.chain().focus().setHorizontalRule().run())}
 					>
 						<Minus size={15} />

--- a/v2/frontend/src/shared/WorktreeSwitcher/WorktreeSwitcher.css.ts
+++ b/v2/frontend/src/shared/WorktreeSwitcher/WorktreeSwitcher.css.ts
@@ -30,7 +30,7 @@ export const backdrop = style({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  background: 'rgba(0, 0, 0, 0.55)',
+  background: `color-mix(in srgb, ${vars.color.bgPrimary} 55%, transparent)`,
   backdropFilter: 'blur(6px)',
   WebkitBackdropFilter: 'blur(6px)',
   animation: `${backdropFadeIn} 100ms ease-out`,
@@ -86,7 +86,7 @@ export const rowGlyph = style({
   alignItems: 'center',
   justifyContent: 'center',
   background: vars.color.bgActive,
-  color: '#ffffff',
+  color: vars.color.textPrimary,
   fontWeight: 700,
   fontSize: '11px',
   fontFamily: vars.font.body,
@@ -98,7 +98,7 @@ export const rowBranch = style({
   fontFamily: vars.font.mono,
   fontSize: '13px',
   fontWeight: 600,
-  color: '#ffffff',
+  color: vars.color.textPrimary,
   overflow: 'hidden',
   textOverflow: 'ellipsis',
   whiteSpace: 'nowrap',
@@ -108,7 +108,7 @@ export const rowBranch = style({
 export const rowProject = style({
   fontFamily: vars.font.body,
   fontSize: '11px',
-  color: 'rgba(255, 255, 255, 0.5)',
+  color: vars.color.textSecondary,
   flexShrink: 0,
   whiteSpace: 'nowrap',
 });
@@ -124,7 +124,7 @@ export const footer = style({
   borderTop: `1px solid ${vars.color.divider}`,
   fontFamily: vars.font.mono,
   fontSize: '12px',
-  color: 'rgba(255, 255, 255, 0.45)',
+  color: vars.color.textDisabled,
   letterSpacing: '0.03em',
   userSelect: 'none',
 });
@@ -138,6 +138,6 @@ export const footerKbd = style({
   borderRadius: '4px',
   fontSize: '11px',
   fontFamily: vars.font.mono,
-  color: 'rgba(255, 255, 255, 0.6)',
+  color: vars.color.textSecondary,
   lineHeight: 1.5,
 });

--- a/v2/frontend/src/styles/journal.css.ts
+++ b/v2/frontend/src/styles/journal.css.ts
@@ -697,7 +697,7 @@ export const dropdownItemActive = style({
 // === Inline Rendering ===
 
 export const markdownLink = style({
-  color: '#a855f7',
+  color: vars.color.accent,
   fontWeight: 600,
   textDecoration: 'none',
   cursor: 'pointer',
@@ -712,7 +712,7 @@ export const bracketSpan = style({
 });
 
 export const prHashSpan = style({
-  color: '#a855f7',
+  color: vars.color.accent,
   fontWeight: 600,
 });
 

--- a/v2/frontend/src/styles/reset.css.ts
+++ b/v2/frontend/src/styles/reset.css.ts
@@ -1,4 +1,5 @@
-import { globalStyle } from '@vanilla-extract/css';
+import { globalStyle, style } from '@vanilla-extract/css';
+import { vars } from './theme.css';
 
 globalStyle('*, *::before, *::after', {
   boxSizing: 'border-box',
@@ -12,8 +13,8 @@ globalStyle('html, body, #root', {
 });
 
 globalStyle('::selection', {
-  backgroundColor: 'rgba(124, 58, 237, 0.3)',
-  color: '#e2e8f0',
+  backgroundColor: vars.color.accentMuted,
+  color: vars.color.textPrimary,
 });
 
 globalStyle('::-webkit-scrollbar', {
@@ -26,10 +27,23 @@ globalStyle('::-webkit-scrollbar-track', {
 });
 
 globalStyle('::-webkit-scrollbar-thumb', {
-  background: 'rgba(124, 58, 237, 0.3)',
+  background: vars.color.accentMuted,
   borderRadius: '3px',
 });
 
 globalStyle('::-webkit-scrollbar-thumb:hover', {
-  background: 'rgba(124, 58, 237, 0.5)',
+  background: `color-mix(in srgb, ${vars.color.accent} 50%, transparent)`,
 });
+
+// Respect prefers-reduced-motion — disable animations/transitions for a11y.
+// Applied to html element so it cascades to all children.
+export const reducedMotion = style({
+  '@media': {
+    '(prefers-reduced-motion: reduce)': {
+      animationDuration: '0.001ms !important',
+      animationIterationCount: '1 !important',
+      transitionDuration: '0.001ms !important',
+    },
+  },
+});
+

--- a/v2/frontend/src/styles/viewer.css.ts
+++ b/v2/frontend/src/styles/viewer.css.ts
@@ -397,3 +397,45 @@ export const wrapToggleBtn = style({
     },
   },
 });
+
+// ── Markdown preview toggle ──────────────────────────────────────────────────
+
+export const previewToggleGroup = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  marginLeft: 'auto',
+  marginRight: vars.space.sm,
+  height: 24,
+  borderRadius: vars.radius.md,
+  border: `1px solid ${vars.color.border}`,
+  overflow: 'hidden',
+});
+
+export const previewToggleBtn = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 4,
+  height: '100%',
+  padding: `0 ${vars.space.sm}`,
+  border: 'none',
+  background: 'transparent',
+  color: vars.color.textSecondary,
+  fontFamily: vars.font.mono,
+  fontSize: '11px',
+  fontWeight: 500,
+  cursor: 'pointer',
+  transition: `color ${vars.animation.fast} ease, background ${vars.animation.fast} ease`,
+  ':hover': {
+    color: vars.color.textPrimary,
+    background: vars.color.bgHover,
+  },
+  selectors: {
+    '&[data-active="true"]': {
+      color: vars.color.accent,
+      background: `color-mix(in srgb, ${vars.color.accentMuted} 40%, transparent)`,
+    },
+    '& + &': {
+      borderLeft: `1px solid ${vars.color.border}`,
+    },
+  },
+});

--- a/v2/frontend/src/utils/format.ts
+++ b/v2/frontend/src/utils/format.ts
@@ -3,17 +3,28 @@
 
 /** Format token count: 48120 → "48.1K", 1200000 → "1.2M" */
 export function formatTokens(n: number | null): string {
-  if (n === null || n === undefined) return '0';
+  if (n == null) return '';
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
   return String(n);
 }
 
-/** Format cost from microdollars: 820000 → "$0.82" */
-export function formatCost(micros: number | null): string {
-  if (micros === null || micros === undefined) return '$0.00';
-  return `$${(micros / 1_000_000).toFixed(2)}`;
+/** Format cost from USD amount: 0.82 → "$0.82", 0.005 → "$0.0050" */
+export function formatCostUsd(usd: number | null): string {
+  if (usd == null || usd === 0) return '$0.00';
+  if (usd < 0.01) return `$${usd.toFixed(4)}`;
+  if (usd < 1) return `$${usd.toFixed(3)}`;
+  return `$${usd.toFixed(2)}`;
 }
+
+/** Format cost from microdollars: 820000 → "$0.82" */
+export function formatCostMicros(micros: number | null): string {
+  if (micros == null) return '$0.00';
+  return formatCostUsd(micros / 1_000_000);
+}
+
+/** @deprecated Use formatCostMicros instead */
+export const formatCost = formatCostMicros;
 
 /** Format unix epoch (seconds or ms) → "HH:MM:SS" */
 export function formatTime(epoch: number | null): string {
@@ -26,18 +37,20 @@ export function formatTime(epoch: number | null): string {
   return `${hh}:${mm}:${ss}`;
 }
 
-/** Relative time for display: epoch → "2m ago" */
-export function relativeTime(epoch: number | null): string {
-  if (!epoch) return '';
-  const ts = epoch > 1e12 ? epoch : epoch * 1000;
-  const secs = Math.floor((Date.now() - ts) / 1000);
-  if (secs < 60) return `${secs}s ago`;
-  const mins = Math.floor(secs / 60);
-  if (mins < 60) return `${mins}m ago`;
-  const hours = Math.floor(mins / 60);
-  if (hours < 24) return `${hours}h ago`;
-  return `${Math.floor(hours / 24)}d ago`;
+/** Relative time for display: epoch/ISO string → "2m ago" */
+export function timeAgo(input: number | string | null): string {
+  if (!input) return '';
+  const ms = typeof input === 'string'
+    ? new Date(input).getTime()
+    : (input > 1e12 ? input : input * 1000);
+  const secs = Math.floor((Date.now() - ms) / 1000);
+  if (secs < 60) return 'just now';
+  if (secs < 3600) return `${Math.floor(secs / 60)}m ago`;
+  if (secs < 86400) return `${Math.floor(secs / 3600)}h ago`;
+  return `${Math.floor(secs / 86400)}d ago`;
 }
+
+export const relativeTime = timeAgo;
 
 /** Known model substring → short display name */
 const MODEL_SHORT_NAMES: Record<string, string> = {

--- a/v2/frontend/src/utils/note-types.ts
+++ b/v2/frontend/src/utils/note-types.ts
@@ -1,0 +1,14 @@
+// Author: Subash Karki
+export const NOTE_COLORS: Record<string, string> = {
+  todo: '#f59e0b',
+  idea: '#3b82f6',
+  bug: '#ef4444',
+  note: '#00d4ff',
+};
+
+export const NOTE_TYPES = [
+  { value: 'todo', label: 'Todo', color: NOTE_COLORS.todo },
+  { value: 'idea', label: 'Idea', color: NOTE_COLORS.idea },
+  { value: 'bug', label: 'Bug', color: NOTE_COLORS.bug },
+  { value: 'note', label: 'Note', color: NOTE_COLORS.note },
+] as const;

--- a/v2/internal/git/github.go
+++ b/v2/internal/git/github.go
@@ -494,7 +494,7 @@ func GetCheckAnnotations(ctx context.Context, repoPath, branch, checkName string
 
 	apiPath := fmt.Sprintf("repos/%s/commits/%s/check-runs", ownerRepo, sha)
 	cmd := exec.CommandContext(ctx, ghBin(), "api", apiPath, "--jq",
-		fmt.Sprintf(".check_runs[] | select(.name == \"%s\") | .id", checkName))
+		fmt.Sprintf(`.check_runs[] | select(.name == "%s") | .id`, jqEscapeString(checkName)))
 	cmd.Dir = repoPath
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
@@ -639,6 +639,13 @@ func parseRunJobFromURL(checkURL string) (runID, jobID string) {
 		jobID = parts[2]
 	}
 	return
+}
+
+// jqEscapeString escapes special characters for safe interpolation into jq string literals.
+func jqEscapeString(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	return s
 }
 
 func parseOwnerRepo(remoteURL string) string {

--- a/v2/internal/journal/generator.go
+++ b/v2/internal/journal/generator.go
@@ -97,18 +97,35 @@ func (g *Generator) EnrichEndOfDay(ctx context.Context, recap string) (string, e
 	}
 
 	prompt := buildEnrichmentPrompt(recap)
-	// Escape single quotes for the shell command template (typical pattern:
-	// `claude --print -p '${PROMPT}'`).
-	escaped := strings.ReplaceAll(prompt, `'`, `'\''`)
-	cmdLine := g.prov.AIGenerateCommand(escaped)
-	if strings.TrimSpace(cmdLine) == "" {
-		return "", fmt.Errorf("journal: provider returned empty command")
-	}
 
 	enrichCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
 	defer cancel()
 
-	c := exec.CommandContext(enrichCtx, "sh", "-c", cmdLine)
+	// Build the command without the prompt interpolated into the shell string.
+	// When the provider supports stdin transport, pass an empty prompt to get
+	// the base command and pipe the real prompt via stdin. For argv transport
+	// we split the fully-interpolated command into exec args — no shell needed.
+	var c *exec.Cmd
+	switch g.prov.PromptTransport() {
+	case provider.PromptStdin:
+		cmdLine := g.prov.AIGenerateCommand("")
+		if strings.TrimSpace(cmdLine) == "" {
+			return "", fmt.Errorf("journal: provider returned empty command")
+		}
+		args := strings.Fields(cmdLine)
+		c = exec.CommandContext(enrichCtx, args[0], args[1:]...)
+		c.Stdin = strings.NewReader(prompt)
+	default:
+		// argv transport: interpolate prompt into the command template and
+		// exec directly — never route through sh -c with user data.
+		cmdLine := g.prov.AIGenerateCommand(prompt)
+		if strings.TrimSpace(cmdLine) == "" {
+			return "", fmt.Errorf("journal: provider returned empty command")
+		}
+		args := strings.Fields(cmdLine)
+		c = exec.CommandContext(enrichCtx, args[0], args[1:]...)
+	}
+
 	out, err := c.Output()
 	if err != nil {
 		return "", fmt.Errorf("journal: enrichment exec: %w", err)
@@ -137,6 +154,8 @@ func buildEnrichmentPrompt(recap string) string {
 }
 
 // run executes a shell command with a 10s timeout. Returns empty string on error.
+// WARNING: cmd must contain only trusted, hardcoded command strings.
+// Never pass user-influenced data through this function.
 func run(cmd string, cwd string) string {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()


### PR DESCRIPTION
## Summary

### Hardening (60 files)
- **Security:** Fix jq expression injection in `GetCheckAnnotations` and shell injection in journal enrichment (replaced `sh -c` with `exec.Command` + stdin transport)
- **Reliability:** Add ErrorBoundary to App shell + per-pane crash recovery, cap composer messages (500), terminal commands (200 with marker disposal), session cache LRU (5)
- **Performance:** Pause all polling intervals when window hidden, immediate refresh on restore
- **Code Quality:** Deduplicate formatTokens (8→1), timeAgo (4→1), formatCost (5→2), binding accessor (32→1), note colors (3→1)
- **Accessibility:** Global `prefers-reduced-motion` support, aria-labels on TipTapEditor toolbar, hardcoded colors replaced with theme tokens

### Markdown Preview (2 files)
- **Source/Preview toggle** in tab bar when viewing `.md` files
- **Cmd+Shift+P** keyboard shortcut
- Zero new dependencies — reuses `marked`, `DOMPurify`, `highlight.js` already in bundle
- Syntax-highlighted code blocks, copy buttons, external link handling
- Reuses orphaned `markdown-preview.css.ts` prose stylesheet (312 lines)

## Changes
- 62 files modified, 3 files created
- Both Go and frontend builds pass clean

## Test plan
- [ ] `go build ./...` passes
- [ ] `pnpm build` passes
- [ ] Open app, switch worktrees — no crashes
- [ ] Open a `.md` file → see Source/Preview toggle in tab bar
- [ ] Click Preview → rendered markdown with formatted headings, code blocks, tables
- [ ] Cmd+Shift+P toggles between source and preview
- [ ] Open terminal, run commands — command history doesn't grow unbounded
- [ ] Minimize/hide window — polling pauses
- [ ] Switch themes — selection highlight, scrollbars, journal links adapt
- [ ] Force a pane error — ErrorBoundary shows recovery UI

PR Generated with AI

Co-Authored-By: AI