### PR TITLE
feat(sidebar): sort projects and live section alphabetically

### DIFF
--- a/v2/frontend/src/components/sidebar/WorktreeSidebar.tsx
+++ b/v2/frontend/src/components/sidebar/WorktreeSidebar.tsx
@@ -57,10 +57,14 @@ export function WorktreeSidebar() {
   // Split filtered projects into favorites and the rest
   const starredIds = createMemo(() => new Set(starredProjects().map((p) => p.id)));
   const favoriteProjects = createMemo(() =>
-    filteredProjects().filter((p) => starredIds().has(p.id)),
+    filteredProjects()
+      .filter((p) => starredIds().has(p.id))
+      .sort((a, b) => a.name.localeCompare(b.name)),
   );
   const otherProjects = createMemo(() =>
-    filteredProjects().filter((p) => !starredIds().has(p.id)),
+    filteredProjects()
+      .filter((p) => !starredIds().has(p.id))
+      .sort((a, b) => a.name.localeCompare(b.name)),
   );
 
   async function handleAddProject() {

--- a/v2/frontend/src/core/signals/live-sessions.ts
+++ b/v2/frontend/src/core/signals/live-sessions.ts
@@ -72,6 +72,6 @@ export const liveWorktrees = createMemo<LiveWorktree[]>(() => {
     }
   }
 
-  result.sort((a, b) => b.terminalCount - a.terminalCount);
+  result.sort((a, b) => a.branch.localeCompare(b.branch) || a.projectName.localeCompare(b.projectName));
   return result;
 });


### PR DESCRIPTION
## Summary
- Favorites and Projects sections now sort alphabetically by project name
- Live section sorts alphabetically by branch name (project name as tiebreaker)
- Previously: projects were in DB insertion order, live section sorted by terminal count

## Test plan
- [ ] Open sidebar with multiple projects — verify alphabetical order
- [ ] Star multiple projects — verify Favorites section is also alphabetical
- [ ] Have 2+ live worktrees — verify Live section sorts by branch name

PR Generated with AI

Co-Authored-By: AI