### PR TITLE
feat(pr): rubber stamp approval for 5/5 Greptile PRs

### DIFF
--- a/v2/frontend/src/components/panes/WorktreeHome.tsx
+++ b/v2/frontend/src/components/panes/WorktreeHome.tsx
@@ -3,7 +3,7 @@
 
 import { createMemo, createSignal, createEffect, on, onCleanup, onMount, Show, For, Index } from 'solid-js';
 import { gsap } from '@/core/animation/gsap-setup';
-import { GitBranch, GitPullRequest, ArrowUp, ArrowDown, FileEdit, FileQuestion, ExternalLink, CheckCircle, XCircle, LoaderCircle, ChevronRight, RefreshCw, Activity, ChevronDown, GitMerge, Rocket, Eye } from 'lucide-solid';
+import { GitBranch, GitPullRequest, ArrowUp, ArrowDown, FileEdit, FileQuestion, ExternalLink, CheckCircle, XCircle, LoaderCircle, ChevronRight, RefreshCw, Activity, ChevronDown, GitMerge, Rocket, Eye, Stamp } from 'lucide-solid';
 import { activeWorktreeId } from '@/core/signals/app';
 import { activeProject, activeWorktree } from '@/core/signals/worktrees';
 import { addTabWithData } from '@/core/panes/signals';
@@ -15,7 +15,7 @@ import { getPref, loadPref, setPref } from '@/core/signals/preferences';
 import { prStatus, setPrStatus, isCreatingPr, setIsCreatingPr, ghAvailable, setGhAvailable } from '@/core/signals/activity';
 import { SessionControls } from '@/shared/SessionControls/SessionControls';
 import { NewWorktreeDialog } from '@/shared/NewWorktreeDialog/NewWorktreeDialog';
-import { getWorkspaceStatus, gitPull, gitPush, getPrStatus, getCiRuns, getCiRunsForBranch, createPrWithAI, listOpenPrs, isGhCliAvailable, getCheckAnnotations, getFailedSteps, getSessionsByProject, getAllRecipes, getFavoriteRecipes, toggleRecipeFavorite, getRepoMergeConfig, mergePr, disableAutoMerge, postMergeCleanup } from '@/core/bindings';
+import { getWorkspaceStatus, gitPull, gitPush, getPrStatus, getCiRuns, getCiRunsForBranch, createPrWithAI, listOpenPrs, isGhCliAvailable, getCheckAnnotations, getFailedSteps, getSessionsByProject, getAllRecipes, getFavoriteRecipes, toggleRecipeFavorite, getRepoMergeConfig, mergePr, disableAutoMerge, postMergeCleanup, rubberStampPr, getGitHubLogin } from '@/core/bindings';
 import { openURL } from '@/core/bindings/shell';
 import { onWailsEvent } from '@/core/events';
 import { showToast, showWarningToast } from '@/shared/Toast/Toast';
@@ -284,6 +284,12 @@ export default function WorktreeHome() {
   const [activityLoading, setActivityLoading] = createSignal(true);
   const [refreshing, setRefreshing] = createSignal(false);
   const [repoMergeCfg, setRepoMergeCfg] = createSignal<RepoMergeConfig | null>(null);
+  const [ghLogin, setGhLogin] = createSignal('');
+
+  onMount(async () => {
+    const login = await getGitHubLogin();
+    setGhLogin(login);
+  });
 
   // Stagger-animate PR cards when the list populates.
   createEffect(() => {
@@ -790,7 +796,7 @@ export default function WorktreeHome() {
                 <For each={openPrs()}>
                   {(pr) => (
                     <div data-pr-card>
-                      <OpenPrCard pr={pr} prStateColor={prStateColor} prAge={prAge} buildCiTooltip={buildCiTooltip} />
+                      <OpenPrCard pr={pr} prStateColor={prStateColor} prAge={prAge} buildCiTooltip={buildCiTooltip} ghLogin={ghLogin()} />
                     </div>
                   )}
                 </For>
@@ -978,11 +984,13 @@ function OpenPrCard(props: {
   prStateColor: (pr: PrStatusType) => string;
   prAge: (iso: string) => string;
   buildCiTooltip: (runs: CiRun[]) => any;
+  ghLogin: string;
 }) {
   const { pr } = props;
   const [expanded, setExpanded] = createSignal(false);
   const [failedRuns, setFailedRuns] = createSignal<CiRun[]>([]);
   const [loadingRuns, setLoadingRuns] = createSignal(false);
+  const [stamping, setStamping] = createSignal(false);
 
   async function toggleExpand(e: MouseEvent) {
     e.stopPropagation();
@@ -1086,6 +1094,30 @@ function OpenPrCard(props: {
       <div class={styles.prCardActions}>
         <Show when={pr.greptile_score}>
           <GreptileBadge score={pr.greptile_score!} />
+        </Show>
+        <Show when={pr.greptile_score?.startsWith('5') && props.ghLogin && props.ghLogin.toLowerCase() !== pr.author.toLowerCase()}>
+          <button
+            type="button"
+            class={`${styles.rubberStampBtn} ${stamping() ? styles.rubberStampBtnActive : ''}`}
+            disabled={stamping()}
+            onClick={(e) => {
+              e.stopPropagation();
+              setStamping(true);
+              const wtId = activeWorktreeId();
+              if (!wtId) { setStamping(false); return; }
+              rubberStampPr(wtId, pr.number).then((err) => {
+                if (err === '') {
+                  showToast('PR #' + pr.number + ' rubber stamped! 🟩');
+                } else {
+                  showWarningToast('Rubber stamp failed: ' + err);
+                }
+                setStamping(false);
+              });
+            }}
+          >
+            <Stamp size={11} class={styles.rubberStampIcon} />
+            {stamping() ? 'Stamping...' : 'Rubber Stamp'}
+          </button>
         </Show>
         <Show when={pr.review_decision === 'APPROVED'}>
           <span class={styles.prApprovedBadge}>

--- a/v2/frontend/src/core/bindings/git.ts
+++ b/v2/frontend/src/core/bindings/git.ts
@@ -202,3 +202,21 @@ export async function cancelWorkflowRun(worktreeId: string, runId: number): Prom
   try { return (await App()?.CancelWorkflowRunForWorkspace(worktreeId, runId)) ?? ''; }
   catch (err) { return err instanceof Error ? err.message : 'cancel failed'; }
 }
+
+// ── Rubber Stamp ──────────────────────────────────────────────────────────
+
+export async function rubberStampPr(worktreeId: string, prNumber: number): Promise<string> {
+  try {
+    return (await App()?.RubberStampPrForWorkspace(worktreeId, prNumber)) ?? 'unknown error';
+  } catch (err) {
+    return String(err);
+  }
+}
+
+export async function getGitHubLogin(): Promise<string> {
+  try {
+    return (await App()?.GetGitHubLoginForWorkspace()) ?? '';
+  } catch {
+    return '';
+  }
+}

--- a/v2/frontend/src/core/bindings/index.ts
+++ b/v2/frontend/src/core/bindings/index.ts
@@ -47,6 +47,8 @@ export {
   dispatchWorkflow,
   rerunWorkflow,
   cancelWorkflowRun,
+  rubberStampPr,
+  getGitHubLogin,
 } from './git';
 export { revealInFinder, openInFinder, openInDefaultApp, openURL } from './shell';
 export { readFileByPath, readFileContents, writeFileContents, getFileAtRevision, getWorkspaceBlame, createFile, createFolder, deleteFile } from './editor';

--- a/v2/frontend/src/styles/home.css.ts
+++ b/v2/frontend/src/styles/home.css.ts
@@ -1989,6 +1989,55 @@ export const prApprovedBadge = style({
   color: vars.color.success,
 });
 
+const stampPress = keyframes({
+  '0%': { transform: 'scale(1) rotate(-6deg)' },
+  '40%': { transform: 'scale(0.85) rotate(-6deg)' },
+  '60%': { transform: 'scale(1.05) rotate(-6deg)' },
+  '100%': { transform: 'scale(1) rotate(-6deg)' },
+});
+
+export const rubberStampBtn = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '4px',
+  padding: '2px 6px',
+  borderRadius: vars.radius.sm,
+  background: `color-mix(in srgb, ${vars.color.success} 8%, transparent)`,
+  border: `1px solid color-mix(in srgb, ${vars.color.success} 20%, transparent)`,
+  cursor: 'pointer',
+  fontFamily: vars.font.mono,
+  fontSize: '0.65rem',
+  fontWeight: 600,
+  color: `color-mix(in srgb, ${vars.color.success} 80%, ${vars.color.textPrimary})`,
+  transition: `all ${vars.animation.fast} ease`,
+  selectors: {
+    '&:hover': {
+      background: `color-mix(in srgb, ${vars.color.success} 18%, transparent)`,
+      borderColor: `color-mix(in srgb, ${vars.color.success} 40%, transparent)`,
+      transform: 'scale(0.97)',
+      boxShadow: `0 1px 4px color-mix(in srgb, ${vars.color.success} 25%, transparent)`,
+    },
+    '&:active': {
+      transform: 'scale(0.92)',
+    },
+    '&:disabled': {
+      opacity: 0.5,
+      cursor: 'not-allowed',
+      transform: 'none',
+      boxShadow: 'none',
+    },
+  },
+});
+
+export const rubberStampIcon = style({
+  transform: 'rotate(-6deg)',
+  transition: `transform ${vars.animation.fast} ease`,
+});
+
+export const rubberStampBtnActive = style({
+  animation: `${stampPress} 0.35s ease`,
+});
+
 export const greptileBadge = style({
   display: 'inline-flex',
   alignItems: 'center',

--- a/v2/internal/app/bindings_github.go
+++ b/v2/internal/app/bindings_github.go
@@ -5,6 +5,7 @@ package app
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/charmbracelet/log"
 	"github.com/subashkarki/phantom-os-v2/internal/db"
@@ -527,6 +528,49 @@ func (a *App) CancelWorkflowRunForWorkspace(worktreeId string, runID int64) stri
 	}
 	log.Info("app/CancelWorkflowRunForWorkspace: success", "worktreeId", worktreeId)
 	return ""
+}
+
+// RubberStampPrForWorkspace approves a PR with a rubber stamp after verifying greptile score and ownership.
+func (a *App) RubberStampPrForWorkspace(worktreeId string, prNumber int) string {
+	log.Info("app/RubberStampPr: called", "worktreeId", worktreeId, "prNumber", prNumber)
+	repoPath, err := a.resolveWorkspacePath(worktreeId)
+	if err != nil {
+		return "failed to resolve workspace"
+	}
+
+	pr, err := git.GetPrStatus(a.ctx, repoPath, fmt.Sprintf("%d", prNumber))
+	if err != nil || pr == nil {
+		return "could not fetch PR status"
+	}
+
+	if pr.GreptileScore == "" || !strings.HasPrefix(pr.GreptileScore, "5") {
+		return "greptile score must be 5/5"
+	}
+
+	login := git.GetGitHubLogin(a.ctx)
+	if login != "" && strings.EqualFold(login, pr.Author) {
+		return "cannot approve your own PR"
+	}
+
+	if err := git.ApprovePr(a.ctx, repoPath, prNumber); err != nil {
+		return err.Error()
+	}
+
+	wailsRuntime.EventsEmit(a.ctx, EventPrApproved, map[string]interface{}{
+		"worktreeId": worktreeId,
+		"prNumber":   prNumber,
+	})
+	select {
+	case a.prRefresh <- struct{}{}:
+	default:
+	}
+	log.Info("app/RubberStampPr: success", "worktreeId", worktreeId, "prNumber", prNumber)
+	return ""
+}
+
+// GetGitHubLoginForWorkspace returns the authenticated GitHub user's login.
+func (a *App) GetGitHubLoginForWorkspace() string {
+	return git.GetGitHubLogin(a.ctx)
 }
 
 // resolveBaseBranch returns the base branch for a workspace by consulting the project's

--- a/v2/internal/app/events.go
+++ b/v2/internal/app/events.go
@@ -48,6 +48,7 @@ const (
 	EventPrMerging    = "pr:merging"     // payload: { worktreeId, prNumber, autoMerge bool }
 	EventPrMerged     = "pr:merged"      // payload: { worktreeId, prNumber }
 	EventMergeFailed  = "pr:merge-failed" // payload: { worktreeId, prNumber, message }
+	EventPrApproved   = "pr:approved"     // payload: { worktreeId, prNumber }
 
 	// MCP self-heal / repair failure surfacing.
 	// payload: { phase: "register" | "enable-projects", error: string, hint?: string }

--- a/v2/internal/git/github.go
+++ b/v2/internal/git/github.go
@@ -10,10 +10,54 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+	"sync"
 
 	"github.com/charmbracelet/log"
 	"github.com/subashkarki/phantom-os-v2/internal/provider"
 )
+
+var (
+	loginOnce   sync.Once
+	cachedLogin string
+)
+
+// GetGitHubLogin returns the authenticated GitHub user's login, cached after first call.
+func GetGitHubLogin(ctx context.Context) string {
+	loginOnce.Do(func() {
+		cmd := exec.CommandContext(ctx, ghBin(), "api", "user", "--jq", ".login")
+		out, err := cmd.Output()
+		if err != nil {
+			log.Error("git/GetGitHubLogin: failed", "err", err)
+			return
+		}
+		cachedLogin = strings.TrimSpace(string(out))
+		log.Info("git/GetGitHubLogin: resolved", "login", cachedLogin)
+	})
+	return cachedLogin
+}
+
+// ApprovePr approves a PR with a rubber stamp comment.
+func ApprovePr(ctx context.Context, repoPath string, prNumber int) error {
+	log.Info("git/ApprovePr: called", "prNumber", prNumber)
+	body := "🏅 **APPROVED** — Rubber Stamped\n\nGreptile Score: 5/5 ✓"
+	cmd := exec.CommandContext(ctx, ghBin(), "pr", "review", fmt.Sprintf("%d", prNumber), "--approve", "--body", body)
+	cmd.Dir = repoPath
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = err.Error()
+		}
+		if len(msg) > 400 {
+			msg = msg[:400] + "..."
+		}
+		log.Error("git/ApprovePr: failed", "prNumber", prNumber, "stderr", msg)
+		return fmt.Errorf("gh pr review --approve: %s", msg)
+	}
+	log.Info("git/ApprovePr: success", "prNumber", prNumber)
+	return nil
+}
 
 // IsGhAvailable returns true if the gh CLI is authenticated and available.
 func IsGhAvailable(ctx context.Context) bool {


### PR DESCRIPTION
## Summary
- Adds a **Rubber Stamp** button on `OpenPrCard` that one-click approves PRs with a 🏅 seal-of-approval comment
- Button only appears when Greptile confidence score is 5/5 and the PR author is not the current user
- Server-side guards re-validate the Greptile score and prevent self-approval before calling `gh pr review --approve`
- Stamp icon tilts -6deg with a press animation for a tactile feel

## Files changed
| Layer | File | Change |
|-------|------|--------|
| Go git | `internal/git/github.go` | `GetGitHubLogin()` (cached) + `ApprovePr()` |
| Go bindings | `internal/app/bindings_github.go` | `RubberStampPrForWorkspace()` with guards |
| Go events | `internal/app/events.go` | `EventPrApproved` constant |
| TS bindings | `frontend/src/core/bindings/git.ts` | `rubberStampPr()` + `getGitHubLogin()` |
| TS exports | `frontend/src/core/bindings/index.ts` | Re-exports |
| CSS | `frontend/src/styles/home.css.ts` | Stamp button + press animation styles |
| UI | `frontend/src/components/panes/WorktreeHome.tsx` | Rubber stamp button in `OpenPrCard` |

## Test plan
- [ ] Open a workspace with open PRs that have a Greptile 5/5 score
- [ ] Verify rubber stamp button appears on PRs by other authors
- [ ] Verify button is hidden on your own PRs
- [ ] Verify button is hidden when Greptile score < 5/5
- [ ] Click rubber stamp — verify GitHub shows approved review with 🏅 seal comment
- [ ] Verify toast notification on success/failure

PR Generated with AI

Co-Authored-By: AI