### PR TITLE
fix(v2): prevent libghostty setlocale×fork deadlock on app launch

### DIFF
--- a/v2/locale_warm.go
+++ b/v2/locale_warm.go
@@ -1,0 +1,34 @@
+//go:build ghostty
+
+// Author: Subash Karki
+package main
+
+/*
+#include <locale.h>
+#include <stdlib.h>
+*/
+import "C"
+
+import "unsafe"
+
+// warmLocale loads the C locale tables once, synchronously, on the main OS
+// thread at startup — before any goroutine forks a subprocess.
+//
+// Why this exists: libghostty's init (ghostty_init → ensureLocale, see
+// internal/terminal/ghostty/bridge.go) calls setlocale(LC_ALL, "") which
+// mallocs while loading the LC_CTYPE / LC_TIME tables. The packaged app kicks
+// off goroutines in App.Startup that immediately fork+exec subprocesses via
+// cgo (git worktree prune, git fetch, gh). Go's cgo exec path uses libc
+// fork(), which runs _malloc_fork_prepare to grab every malloc zone lock. If a
+// fork lands while libghostty's setlocale is mid-malloc holding a zone lock,
+// the two lock orders invert and the process deadlocks on launch (the kernel
+// reports a 2-thread turnstile deadlock; the app hangs ~40s and is killed).
+//
+// Loading the tables here, before any fork can happen, makes every later
+// setlocale call — including libghostty's — a cached read with no malloc,
+// closing the race permanently. libghostty itself is untouched.
+func warmLocale() {
+	empty := C.CString("")
+	defer C.free(unsafe.Pointer(empty))
+	C.setlocale(C.LC_ALL, empty)
+}

--- a/v2/locale_warm_stub.go
+++ b/v2/locale_warm_stub.go
@@ -1,0 +1,9 @@
+//go:build !ghostty
+
+// Author: Subash Karki
+package main
+
+// warmLocale is a no-op when libghostty is not linked. The fork()/setlocale()
+// startup deadlock it guards against only occurs in the cgo (ghostty) build;
+// see locale_warm.go for the full explanation.
+func warmLocale() {}

--- a/v2/main.go
+++ b/v2/main.go
@@ -43,6 +43,11 @@ import (
 var assets embed.FS
 
 func main() {
+	// Pre-warm the C locale on the main thread before any goroutine can fork.
+	// Prevents a libghostty setlocale() × fork() deadlock on launch — see
+	// locale_warm.go.
+	warmLocale()
+
 	backfillJournal := false
 	for _, arg := range os.Args[1:] {
 		if arg == "--backfill-journal" {


### PR DESCRIPTION
## Problem
Packaged Phantom **0.1.64 hangs ~40s on launch then is killed** by macOS. Dev mode (`wails dev`) is unaffected.

## Root cause (from macOS hang reports)
Kernel-detected **2-thread deadlock** at startup — both hang reports were 43/43 samples stuck in this exact state (100% reproducible):
- **Thread A:** libghostty init `ghostty_init → ensureLocale → setlocale(LC_ALL,"")` mallocs while loading the LC_CTYPE/LC_TIME tables, holding a malloc zone lock.
- **Thread B:** a startup goroutine forks a subprocess (`git worktree prune`, `git fetch`, `gh` — kicked off in `App.Startup`). Go's cgo exec path uses libc `fork()`, whose `_malloc_fork_prepare` grabs the malloc zone locks.
- Lock order inverts → deadlock. Dev mode escaped only via different startup timing; the packaged app hit it every launch.

## Fix
Pre-warm the C locale on the **main thread as the first statement of `main()`**, before any goroutine can fork. Once the locale tables are cached, libghostty's later `setlocale` is a no-malloc read → the race window is closed permanently. **libghostty is kept and untouched** (it's fast and nice).

- `v2/locale_warm.go` (`//go:build ghostty`) — cgo `setlocale(LC_ALL,"")`
- `v2/locale_warm_stub.go` (`//go:build !ghostty`) — no-op
- `v2/main.go` — calls `warmLocale()` first

## Verification
- `go build ./...` (stub path) ✅
- `go build -tags ghostty .` (shipping cgo + libghostty) ✅
- Runtime: **pending** — needs a fresh signed release installed to confirm on the packaged app.

## Note
`main.go` has a pre-existing gofmt import-order issue (unrelated) — left untouched per scope.

PR Generated with AI

Co-Authored-By: AI