### PR TITLE
fix(v2): serialize native terminal app init to prevent multi-session crash

### DIFF
--- a/v2/internal/app/app.go
+++ b/v2/internal/app/app.go
@@ -138,10 +138,17 @@ type App struct {
 	// Native (libghostty) terminal state — lazily initialized on first
 	// NativeTerminalCreate call when the feature flag is on. The map is
 	// keyed by frontend pane (terminal) ID. See bindings_native_terminal.go.
-	nativeTerminals  map[string]nativeTerminal
-	nativeHost       nativeHostHandle
-	ghosttyApp       ghosttyAppHandle
-	nativeMu         sync.Mutex
+	nativeTerminals map[string]nativeTerminal
+	nativeHost      nativeHostHandle
+	ghosttyApp      ghosttyAppHandle
+	nativeMu        sync.Mutex
+	// ghosttyInitMu serializes lazy creation of the process-wide
+	// ghosttyApp singleton. libghostty is one ghostty_app_t per process,
+	// so concurrent NativeTerminalCreate calls (multiple panes/sessions
+	// mounting at once) must not each call NewApp. Kept separate from
+	// nativeMu so it can be held across the main-thread dispatch_sync in
+	// NewApp without risking the callback deadlock nativeMu guards against.
+	ghosttyInitMu sync.Mutex
 }
 
 func New() *App {
@@ -290,7 +297,6 @@ func (a *App) Startup(ctx context.Context) {
 		log.Info("app: composer V2 context enricher wired")
 	}
 
-
 	// Initialize the conflict tracker and wire it into the Composer service
 	// so simultaneous panes editing the same repo surface warnings.
 	a.ConflictTracker = conflict.NewTracker(nil)
@@ -407,7 +413,6 @@ func (a *App) Startup(ctx context.Context) {
 
 	// Start GitHub poller — emits pr:updated / ci:updated / prs:list-updated on change.
 	go a.startGitHubPoller()
-
 
 	// Start git filesystem watcher for instant change detection.
 	if gw, err := git.NewWatcher(a.ctx); err == nil {

--- a/v2/internal/app/bindings_native_terminal.go
+++ b/v2/internal/app/bindings_native_terminal.go
@@ -78,25 +78,47 @@ func (a *App) NativeTerminalCreate(paneID, worktreeID, cwd string) (string, erro
 	host := a.nativeHost
 	a.nativeMu.Unlock()
 
-	// Heavy work (dispatch_sync to main thread) runs WITHOUT the mutex.
+	// Lazy-init the process-wide ghostty app exactly once. The check-then-act
+	// on a.ghosttyApp is NOT atomic (the expensive NewApp runs with nativeMu
+	// released to avoid a main-thread-callback deadlock), so two concurrent
+	// creates would each see nil and each call ghostty_app_new — but libghostty
+	// is one ghostty_app_t per process, which crashes. ghosttyInitMu serializes
+	// the init and a re-check under it collapses the race to a single NewApp.
+	// Heavy work (dispatch_sync to main thread) still runs WITHOUT nativeMu.
 	if gapp == nil {
-		// Register the event dispatcher before creating the app so callbacks
-		// can emit events from the very first tick.
-		ghostty.SetEventDispatcher(func(event string, data interface{}) {
-			wailsRuntime.EventsEmit(a.ctx, event, data)
-		})
+		a.ghosttyInitMu.Lock()
 
-		var err error
-		gapp, err = ghostty.NewApp()
-		if err != nil {
-			return "", err
+		a.nativeMu.Lock()
+		gapp = a.ghosttyApp
+		a.nativeMu.Unlock()
+
+		if gapp == nil {
+			// Register the event dispatcher before creating the app so callbacks
+			// can emit events from the very first tick.
+			ghostty.SetEventDispatcher(func(event string, data interface{}) {
+				wailsRuntime.EventsEmit(a.ctx, event, data)
+			})
+
+			newApp, err := ghostty.NewApp()
+			if err != nil {
+				a.ghosttyInitMu.Unlock()
+				return "", err
+			}
+
+			// Dark theme (Phantom is always dark for now).
+			newApp.SetColorScheme(true)
+
+			// Start the ~60Hz tick loop that drives rendering + IO.
+			ghostty.StartTickLoop(newApp, a.ctx)
+
+			a.nativeMu.Lock()
+			a.ghosttyApp = newApp
+			a.nativeMu.Unlock()
+
+			gapp = newApp
 		}
 
-		// Dark theme (Phantom is always dark for now).
-		gapp.SetColorScheme(true)
-
-		// Start the ~60Hz tick loop that drives rendering + IO.
-		ghostty.StartTickLoop(gapp, a.ctx)
+		a.ghosttyInitMu.Unlock()
 	}
 	if host == nil {
 		var err error
@@ -118,9 +140,10 @@ func (a *App) NativeTerminalCreate(paneID, worktreeID, cwd string) (string, erro
 	host.FocusSubview(view)
 	ghostty.SetFocusedSurface(surf)
 
-	// Re-acquire lock to store results.
+	// Re-acquire lock to store results. a.ghosttyApp is already persisted by
+	// the init block above (under ghosttyInitMu), so only the host + map entry
+	// are stored here.
 	a.nativeMu.Lock()
-	a.ghosttyApp = gapp
 	a.nativeHost = host
 	a.nativeTerminals[paneID] = nativeTerminal{surface: surf, view: view}
 	a.nativeMu.Unlock()

--- a/v2/internal/app/native_terminal_init_sim_test.go
+++ b/v2/internal/app/native_terminal_init_sim_test.go
@@ -1,0 +1,134 @@
+// Author: Subash Karki
+//
+// Simulation test for the native-terminal lazy-init race fix.
+//
+// libghostty is one ghostty_app_t per process; before the fix, two concurrent
+// NativeTerminalCreate calls (multiple sessions/terminals mounting at once)
+// could each pass the `a.ghosttyApp == nil` check and each call ghostty.NewApp,
+// creating two apps in a library that allows one — which crashed.
+//
+// The real path needs a Metal context + NSWindow, so it cannot run headless.
+// This test reproduces the EXACT locking discipline of NativeTerminalCreate
+// against a fake "newApp" that counts how many times it runs, under the
+// worst-case interleaving (every goroutine passes the nil-check before any
+// init runs, enforced by a barrier). It proves the fixed locking collapses N
+// concurrent creates to a single app init, while the pre-fix logic would
+// create N. Run with -race.
+package app
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// appInitSim mirrors the App fields that NativeTerminalCreate's lazy init
+// touches: the ghosttyApp singleton, the nativeMu guarding it, and the
+// dedicated ghosttyInitMu that serializes creation.
+type appInitSim struct {
+	nativeMu      sync.Mutex
+	ghosttyInitMu sync.Mutex
+	app           *struct{} // stands in for *ghostty.App
+	newAppCalls   atomic.Int64
+}
+
+// fakeNewApp stands in for ghostty.NewApp — the one-per-process constructor.
+func (s *appInitSim) fakeNewApp() *struct{} {
+	s.newAppCalls.Add(1)
+	return &struct{}{}
+}
+
+// createSafe mirrors the FIXED NativeTerminalCreate lazy-init: snapshot under
+// nativeMu, then a double-checked init under the dedicated ghosttyInitMu.
+func (s *appInitSim) createSafe(barrier *sync.WaitGroup, release <-chan struct{}) {
+	s.nativeMu.Lock()
+	gapp := s.app
+	s.nativeMu.Unlock()
+
+	if gapp == nil {
+		// Synchronize all goroutines at the worst-case point: every caller has
+		// passed the outer nil-check before any init runs.
+		barrier.Done()
+		<-release
+
+		s.ghosttyInitMu.Lock()
+		s.nativeMu.Lock()
+		gapp = s.app
+		s.nativeMu.Unlock()
+		if gapp == nil {
+			newApp := s.fakeNewApp()
+			s.nativeMu.Lock()
+			s.app = newApp
+			s.nativeMu.Unlock()
+		}
+		s.ghosttyInitMu.Unlock()
+	}
+}
+
+// createRacy mirrors the PRE-FIX lazy-init: a check-then-act with no init
+// mutex. Kept to prove the simulation harness actually detects the bug the
+// fix prevents.
+func (s *appInitSim) createRacy(barrier *sync.WaitGroup, release <-chan struct{}) {
+	s.nativeMu.Lock()
+	gapp := s.app
+	s.nativeMu.Unlock()
+
+	if gapp == nil {
+		barrier.Done()
+		<-release
+
+		newApp := s.fakeNewApp()
+		s.nativeMu.Lock()
+		s.app = newApp
+		s.nativeMu.Unlock()
+	}
+}
+
+// runConcurrentCreates fires `n` goroutines that all reach the init point
+// simultaneously (via the barrier), then returns how many times the app was
+// constructed.
+func runConcurrentCreates(n int, create func(*sync.WaitGroup, <-chan struct{})) int64 {
+	var barrier sync.WaitGroup
+	barrier.Add(n)
+	release := make(chan struct{})
+
+	var done sync.WaitGroup
+	done.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer done.Done()
+			create(&barrier, release)
+		}()
+	}
+
+	// Wait until every goroutine has passed the nil-check, then release them
+	// all at once for maximum contention on the init path.
+	barrier.Wait()
+	close(release)
+	done.Wait()
+	return 0
+}
+
+const simConcurrency = 200
+
+func TestNativeTerminalInit_SingleAppUnderConcurrentCreates(t *testing.T) {
+	s := &appInitSim{}
+	runConcurrentCreates(simConcurrency, s.createSafe)
+
+	if got := s.newAppCalls.Load(); got != 1 {
+		t.Fatalf("ghostty app created %d times under %d concurrent creates; want exactly 1 (libghostty is one app per process)", got, simConcurrency)
+	}
+}
+
+func TestNativeTerminalInit_PreFixWouldDoubleInit(t *testing.T) {
+	s := &appInitSim{}
+	runConcurrentCreates(simConcurrency, s.createRacy)
+
+	// This documents WHY ghosttyInitMu exists: without it, every concurrent
+	// caller that passed the nil-check constructs its own app. If this ever
+	// reported 1, the simulation barrier would be broken and the safe-path
+	// test above would be meaningless.
+	if got := s.newAppCalls.Load(); got <= 1 {
+		t.Fatalf("pre-fix simulation created the app %d times; expected >1 to prove the harness detects the double-init the fix prevents", got)
+	}
+}


### PR DESCRIPTION
## Problem

Phantom **0.165 crashes as soon as a second cloud session or terminal is opened.** `0.165` is the first release that actually ships the native (Metal) libghostty terminal — prior releases silently shipped a no-op stub due to a universal-build path mismatch (fixed in 6a92580), so this path had never run for real users.

## Root cause

libghostty is **one `ghostty_app_t` per process**. `NativeTerminalCreate` did a check-then-act on the shared `a.ghosttyApp`: it snapshotted `gapp` under `nativeMu`, released the lock, then ran the slow `ghostty.NewApp()` (main-thread `dispatch_sync`) before storing the result. The check and the store are not atomic. Every `NativeTerminalPane` fires `NativeTerminalCreate` from its own `onMount`, so two terminals / cloud sessions mounting in the same tick both see `nil` → each calls `ghostty_app_new` → two apps + two tick loops → crash. One terminal never races. Multiple sessions per project/worktree make it trivially reproducible.

## Fix

- Add a dedicated `ghosttyInitMu` + **double-checked locking** around lazy app init — separate from `nativeMu` so it can be held across the main-thread `dispatch_sync` without the callback deadlock `nativeMu` guards against.
- Persist `a.ghosttyApp` *inside* the guarded region so a second concurrent caller re-reads the real app, not `nil`; drop the now-redundant re-store.
- Hot path (app already created) skips `ghosttyInitMu` entirely.

## Test — concurrency simulation

The real path needs Metal + NSWindow, so it can't run headless. `native_terminal_init_sim_test.go` reproduces the exact lock discipline against a counting fake `NewApp`, with a barrier forcing all 200 goroutines past the nil-check before any init — the precise interleaving that crashed.

- `TestNativeTerminalInit_SingleAppUnderConcurrentCreates` → fixed path inits **exactly once**
- `TestNativeTerminalInit_PreFixWouldDoubleInit` → old path inits **N times** (proves the harness detects the bug)

## Verification

`go build -tags ghostty` · `go vet -tags ghostty` clean · `gofmt` clean · `go test -race -count=5 ./internal/app/` → 10/10 pass, no data race

Author: Subash Karki