### PR TITLE
fix(v2): close native terminal use-after-free crash class (0.1.65–0.1.68)

### DIFF
--- a/v2/frontend/src/app.tsx
+++ b/v2/frontend/src/app.tsx
@@ -87,11 +87,11 @@ export function App() {
     await waitForWails();
 
     // Sync native-terminal feature flag so pane routing in signals.ts is
-    // correct before any tab is created.
+    // correct before any tab is created. Memoized — restore paths await the
+    // same promise (ensureNativeTerminalFlagSynced) for race-safe demotion.
     try {
-      const { nativeTerminalIsEnabled } = await import('@/core/bindings/native-terminal');
-      const { setNativeTerminalFlagCached } = await import('@/core/panes/signals');
-      setNativeTerminalFlagCached(await nativeTerminalIsEnabled());
+      const { ensureNativeTerminalFlagSynced } = await import('@/core/bindings/native-terminal');
+      await ensureNativeTerminalFlagSynced();
     } catch {}
 
     const savedTheme = await loadPref('theme');

--- a/v2/frontend/src/components/panes/NativeTerminalPane.tsx
+++ b/v2/frontend/src/components/panes/NativeTerminalPane.tsx
@@ -6,7 +6,7 @@
 // (PhantomTerminalView) attached to the Wails NSWindow's contentView and
 // positioned to match this div on every layout change.
 
-import { onMount, onCleanup, createEffect } from 'solid-js';
+import { onMount, onCleanup, createEffect, createSignal, Show } from 'solid-js';
 import {
   nativeTerminalCreate,
   nativeTerminalDestroy,
@@ -15,6 +15,7 @@ import {
   nativeTerminalSetPlacement,
 } from '@/core/bindings/native-terminal';
 import { activePaneId } from '@/core/panes/signals';
+import { vars } from '@/styles/theme.css';
 
 interface NativeTerminalPaneProps {
   paneId: string;
@@ -28,6 +29,10 @@ export default function NativeTerminalPane(props: NativeTerminalPaneProps) {
   let scrollListenerTarget: Window | undefined;
   let lastBounds = { x: 0, y: 0, w: 0, h: 0 };
   let alive = true;
+  let waitRafId: number | undefined;
+  let retryTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const [createError, setCreateError] = createSignal<string | null>(null);
 
   const pushPlacement = () => {
     if (!alive || !containerRef) return;
@@ -41,13 +46,59 @@ export default function NativeTerminalPane(props: NativeTerminalPaneProps) {
     void nativeTerminalSetPlacement(props.paneId, x, y, w, h);
   };
 
+  // The NSView attach path needs a realized window + real bounds; the first
+  // frame after mount can report 0x0, so wait for layout before creating.
+  const waitForNonZeroRect = () =>
+    new Promise<void>((resolve) => {
+      const check = () => {
+        if (!alive) { resolve(); return; }
+        const rect = containerRef?.getBoundingClientRect();
+        if (rect && rect.width > 0 && rect.height > 0) { resolve(); return; }
+        waitRafId = requestAnimationFrame(check);
+      };
+      check();
+    });
+
+  const delay = (ms: number) =>
+    new Promise<void>((resolve) => { retryTimer = setTimeout(resolve, ms); });
+
+  const MAX_CREATE_ATTEMPTS = 8;
+
+  // `window not ready` is the transient early-boot error from the Go binding
+  // (see contract at FindHostWindow in internal/terminal/ghostty/wails_host.go) — retry with linear backoff.
+  // Anything else (`native terminal disabled`, `libghostty not available`) is permanent.
+  const createWithRetry = async (): Promise<string | null> => {
+    for (let attempt = 1; attempt <= MAX_CREATE_ATTEMPTS; attempt++) {
+      try {
+        return await nativeTerminalCreate(
+          props.paneId,
+          props.worktreeId ?? '',
+          props.cwd ?? '',
+        );
+      } catch (error) {
+        if (!alive) return null;
+        const msg = error instanceof Error ? error.message : String(error);
+        if (!msg.includes('window not ready') || attempt === MAX_CREATE_ATTEMPTS) {
+          setCreateError(msg || 'native terminal failed to start');
+          return null;
+        }
+        await delay(250 * attempt);
+        if (!alive) return null;
+      }
+    }
+    return null;
+  };
+
   onMount(async () => {
-    const id = await nativeTerminalCreate(
-      props.paneId,
-      props.worktreeId ?? '',
-      props.cwd ?? '',
-    );
-    if (!alive || !id) return;
+    await waitForNonZeroRect();
+    if (!alive) return;
+
+    const id = await createWithRetry();
+    if (!alive) return;
+    if (!id) {
+      if (!createError()) setCreateError('native terminal unavailable');
+      return;
+    }
 
     pushPlacement();
 
@@ -70,6 +121,8 @@ export default function NativeTerminalPane(props: NativeTerminalPaneProps) {
 
   onCleanup(() => {
     alive = false;
+    if (waitRafId !== undefined) cancelAnimationFrame(waitRafId);
+    if (retryTimer !== undefined) clearTimeout(retryTimer);
     if (resizeObserver) resizeObserver.disconnect();
     if (scrollListenerTarget) {
       scrollListenerTarget.removeEventListener('scroll', pushPlacement, true);
@@ -91,6 +144,23 @@ export default function NativeTerminalPane(props: NativeTerminalPaneProps) {
         width: '100%',
         background: 'transparent',
       }}
-    />
+    >
+      <Show when={createError()}>
+        <div
+          style={{
+            display: 'flex',
+            'align-items': 'center',
+            'justify-content': 'center',
+            height: '100%',
+            padding: vars.space.md,
+            color: vars.color.textSecondary,
+            'font-family': vars.font.mono,
+            'text-align': 'center',
+          }}
+        >
+          {createError()}
+        </div>
+      </Show>
+    </div>
   );
 }

--- a/v2/frontend/src/core/bindings/native-terminal.ts
+++ b/v2/frontend/src/core/bindings/native-terminal.ts
@@ -1,6 +1,7 @@
 // Author: Subash Karki
 
 import { App } from './_app';
+import { setNativeTerminalFlagCached, getNativeTerminalFlagCached } from '@/core/panes/signals';
 
 export async function nativeTerminalIsEnabled(): Promise<boolean> {
   try {
@@ -8,6 +9,26 @@ export async function nativeTerminalIsEnabled(): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+// Race-safe source of truth for the native-terminal flag at boot. The cached
+// flag in panes/signals.ts is set asynchronously, so early restore paths must
+// await this instead of trusting the (possibly unsynced) cache. After the
+// first sync the live cache wins — toggles update it via
+// setNativeTerminalFlagCached.
+let flagSynced = false;
+let flagSyncPromise: Promise<boolean> | null = null;
+
+export function ensureNativeTerminalFlagSynced(): Promise<boolean> {
+  if (flagSynced) return Promise.resolve(getNativeTerminalFlagCached());
+  if (!flagSyncPromise) {
+    flagSyncPromise = nativeTerminalIsEnabled().then((on) => {
+      setNativeTerminalFlagCached(on);
+      flagSynced = true;
+      return on;
+    });
+  }
+  return flagSyncPromise;
 }
 
 export async function setNativeTerminalEnabled(on: boolean): Promise<void> {
@@ -18,6 +39,9 @@ export async function setNativeTerminalEnabled(on: boolean): Promise<void> {
   }
 }
 
+// Unlike the other wrappers this RETHROWS so the caller can distinguish the
+// transient `window not ready` error (retryable, see contract at
+// FindHostWindow in internal/terminal/ghostty/wails_host.go) from permanent failures.
 export async function nativeTerminalCreate(
   paneId: string,
   worktreeId: string,
@@ -28,7 +52,7 @@ export async function nativeTerminalCreate(
     return typeof id === 'string' ? id : null;
   } catch (error) {
     console.error('[native-terminal] create failed', { paneId, error });
-    return null;
+    throw error;
   }
 }
 

--- a/v2/frontend/src/core/panes/signals.ts
+++ b/v2/frontend/src/core/panes/signals.ts
@@ -71,12 +71,34 @@ function flushPendingSave(worktreeId: string): void {
   }
 }
 
-// Remove panes with deleted types (journal, diff, playground, chat, markdown-preview, composer-v1)
-function sanitizePanes(state: WorkspaceState): WorkspaceState {
+// Rewrite 'native-terminal' leaves to 'terminal' across a layout tree.
+// PaneContainer renders from the leaf's paneType, so demotion must touch the
+// layout as well as the panes map.
+function demoteNativeLeaves(node: LayoutNode): void {
+  if (node.type === 'leaf') {
+    if (node.paneType === 'native-terminal') node.paneType = 'terminal';
+    return;
+  }
+  demoteNativeLeaves(node.first);
+  demoteNativeLeaves(node.second);
+}
+
+// Remove panes with deleted types (journal, diff, playground, chat, markdown-preview, composer-v1).
+// When the native-terminal flag is off, demote persisted 'native-terminal'
+// panes to 'terminal' so they reattach as web terminals. Restore paths run
+// before the async flag sync may have landed, so they must pass the awaited
+// flag (ensureNativeTerminalFlagSynced) instead of relying on the cache.
+function sanitizePanes(state: WorkspaceState, nativeEnabled: boolean): WorkspaceState {
   for (const tab of state.tabs ?? []) {
     const staleIds = Object.keys(tab.panes).filter(id => !VALID_PANE_TYPES.has(tab.panes[id].kind));
     for (const id of staleIds) {
       delete tab.panes[id];
+    }
+    if (!nativeEnabled) {
+      for (const pane of Object.values(tab.panes)) {
+        if (pane.kind === 'native-terminal') pane.kind = 'terminal';
+      }
+      if (tab.layout) demoteNativeLeaves(tab.layout);
     }
   }
   return state;
@@ -88,9 +110,10 @@ export async function restoreWorkspaceState(worktreeId: string): Promise<boolean
   // completion, drop stale).
   const startGen = switchGeneration;
   try {
+    const nativeEnabled = await ensureNativeTerminalFlagSynced();
     const stateJSON = await App()?.GetWorkspaceState(worktreeId);
     if (!stateJSON) return false;
-    const restored = sanitizePanes(JSON.parse(stateJSON) as WorkspaceState);
+    const restored = sanitizePanes(JSON.parse(stateJSON) as WorkspaceState, nativeEnabled);
     if (!restored.tabs?.length) return false;
     // The async fetch may resolve after the user switched away. Applying it now
     // would clobber the live worktree's panes with this (stale) worktree's state.
@@ -104,11 +127,12 @@ export async function restoreWorkspaceState(worktreeId: string): Promise<boolean
 
 export async function bootstrapWorkspaceStates(): Promise<void> {
   try {
+    const nativeEnabled = await ensureNativeTerminalFlagSynced();
     const allStates: Record<string, string> | undefined = await App()?.GetAllWorkspaceStates();
     if (!allStates) return;
     for (const [worktreeId, stateJSON] of Object.entries(allStates)) {
       try {
-        const state = sanitizePanes(JSON.parse(stateJSON) as WorkspaceState);
+        const state = sanitizePanes(JSON.parse(stateJSON) as WorkspaceState, nativeEnabled);
         if (state.tabs?.length) {
           stateCache.set(worktreeId, state);
         }
@@ -121,6 +145,7 @@ export async function bootstrapWorkspaceStates(): Promise<void> {
   }
 }
 import type { WorkspaceState, Tab, PaneType, PaneLeaf, LayoutNode } from './types';
+import { ensureNativeTerminalFlagSynced } from '@/core/bindings/native-terminal';
 import {
   uid,
   removePaneFromLayout,

--- a/v2/internal/app/app.go
+++ b/v2/internal/app/app.go
@@ -259,6 +259,11 @@ func (a *App) Startup(ctx context.Context) {
 		}
 	}
 
+	// Surface native-terminal crashes from the previous session. libghostty's
+	// sentry-native handler swallows native crashes, so without this check the
+	// only evidence is a silent exit.
+	go checkGhosttyCrashEnvelopes()
+
 	// Initialize session controller tables.
 	if a.SessionCtrl != nil {
 		if err := a.SessionCtrl.Init(a.ctx); err != nil {

--- a/v2/internal/app/bindings_native_terminal.go
+++ b/v2/internal/app/bindings_native_terminal.go
@@ -79,7 +79,6 @@ func (a *App) NativeTerminalCreate(paneID, worktreeID, cwd string) (string, erro
 		return paneID, nil
 	}
 	gapp := a.ghosttyApp
-	host := a.nativeHost
 	a.nativeMu.Unlock()
 
 	// Lazy-init the process-wide ghostty app exactly once. The check-then-act
@@ -124,12 +123,15 @@ func (a *App) NativeTerminalCreate(paneID, worktreeID, cwd string) (string, erro
 
 		a.ghosttyInitMu.Unlock()
 	}
-	if host == nil {
-		var err error
-		host, err = ghostty.FindHostWindow()
-		if err != nil {
-			return "", err
-		}
+	// Always re-resolve the host window per create — never trust a cached
+	// handle. The 0.1.65 crash class: a stale cached NSWindow (from a
+	// transient boot window) whose contentView was freed got messaged in a
+	// queued attach block. FindHostWindow is strict-match (WKWebView window
+	// only) and returns a transient "window not ready" error the frontend
+	// retries on.
+	host, err := ghostty.FindHostWindow()
+	if err != nil {
+		return "", err
 	}
 
 	surf, err := gapp.NewSurface(ghostty.SurfaceOptions{
@@ -184,8 +186,17 @@ func (a *App) NativeTerminalSetPlacement(paneID string, x, y, width, height floa
 }
 
 // NativeTerminalDestroy removes the NSView and frees the surface.
-// Sends ghostty_surface_request_close first so the PTY flushes / shell
-// exits cleanly before the surface tears down.
+//
+// Lifecycle serialization (the 0.1.65/0.1.66 crash class):
+//  1. The map entry is deleted under nativeMu BEFORE any teardown runs, so
+//     no other binding (Focus/SetPlacement/Create) can pick up the dying
+//     uintptr handles — no Go-side use after free.
+//  2. Teardown is then one serialized main-queue chain, in enqueue order:
+//     request close (sync, PTY flush) → detach view (autoreleased) → free
+//     surface (sync). The main queue is serial, so any
+//     attach/focus block queued earlier (at create time) runs BEFORE the
+//     free — a queued attach can never message a freed view or surface.
+//     Do not reorder these calls or move any of them off the main queue.
 func (a *App) NativeTerminalDestroy(paneID string) {
 	a.nativeMu.Lock()
 	t, ok := a.nativeTerminals[paneID]

--- a/v2/internal/app/ghostty_crash_check.go
+++ b/v2/internal/app/ghostty_crash_check.go
@@ -1,0 +1,92 @@
+// Author: Subash Karki
+//
+// Crash-envelope observability for the native (libghostty) terminal.
+// libghostty bundles a sentry-native crash handler that swallows native
+// crashes (EXC_BAD_ACCESS etc.) and writes an envelope to
+// ~/.local/state/ghostty/crash/ — the app just exits silently. At startup
+// we scan that directory for envelopes newer than the previous launch and
+// log loudly so a native-terminal crash from the last session is visible
+// instead of silent. Dependency-free: os.ReadDir + ModTime, with the
+// last-seen timestamp persisted under ~/.phantom-os/ghostty-crash-marker.
+
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/log"
+)
+
+const ghosttyCrashMarkerFile = "ghostty-crash-marker"
+
+// checkGhosttyCrashEnvelopes detects libghostty crash envelopes written
+// since the previous app launch and warns loudly. On the very first run
+// (no marker yet) it only initializes the marker — pre-existing envelopes
+// may belong to a standalone Ghostty install and would be noise.
+func checkGhosttyCrashEnvelopes() {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return
+	}
+	crashDir := filepath.Join(home, ".local", "state", "ghostty", "crash")
+	markerPath := filepath.Join(home, ".phantom-os", ghosttyCrashMarkerFile)
+
+	var lastSeen time.Time
+	markerExisted := false
+	if raw, rerr := os.ReadFile(markerPath); rerr == nil {
+		if t, perr := time.Parse(time.RFC3339Nano, strings.TrimSpace(string(raw))); perr == nil {
+			lastSeen = t
+			markerExisted = true
+		}
+	}
+
+	now := time.Now()
+	defer writeGhosttyCrashMarker(markerPath, now)
+
+	// First run (no marker yet): just initialize the marker, skip the scan.
+	if !markerExisted {
+		return
+	}
+
+	entries, err := os.ReadDir(crashDir)
+	if err != nil {
+		return // directory absent = no crashes ever
+	}
+
+	count := 0
+	var newestName string
+	var newestMod time.Time
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".ghosttycrash") {
+			continue
+		}
+		info, ierr := e.Info()
+		if ierr != nil || !info.ModTime().After(lastSeen) {
+			continue
+		}
+		count++
+		if info.ModTime().After(newestMod) {
+			newestMod = info.ModTime()
+			newestName = e.Name()
+		}
+	}
+
+	if count == 0 {
+		return
+	}
+	log.Warn("NATIVE TERMINAL CRASHED LAST SESSION — new libghostty crash envelope(s) found",
+		"count", count,
+		"newest", newestName,
+		"dir", crashDir,
+		"hint", "libghostty's bundled sentry-native handler swallows the crash, so the app exited silently; inspect the envelope for the native stack")
+}
+
+func writeGhosttyCrashMarker(path string, t time.Time) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return
+	}
+	_ = os.WriteFile(path, []byte(t.Format(time.RFC3339Nano)), 0o644)
+}

--- a/v2/internal/terminal/ghostty/native_host.m
+++ b/v2/internal/terminal/ghostty/native_host.m
@@ -3,8 +3,17 @@
 // Native host helpers — find the Wails NSWindow (the one that owns the
 // WKWebView) and attach/detach PhantomTerminalView instances as siblings
 // of the web content view. Wails v2 does not expose its NSWindow from Go,
-// so we walk NSApp's window list and pick the first window whose view
-// hierarchy contains a WKWebView.
+// so we walk NSApp's window list and pick the window whose view hierarchy
+// contains a WKWebView. Strict match only — no fallback. A transient boot
+// window grabbed by a fallback gets cached by the Go side and its views
+// die when boot settles, leaving dangling pointers (the 0.1.65 native
+// terminal crash class).
+//
+// This file is compiled WITHOUT ARC. Every ObjC pointer captured into a
+// dispatch block is CFRetain'd at capture (before dispatch) and CFRelease'd
+// exactly once at the end of the block, on every exit path. Pointers are
+// captured as raw void* so MRC block-copy never implicitly retains them at
+// an unpredictable time — lifetime is owned explicitly here.
 
 #import <Cocoa/Cocoa.h>
 #import <WebKit/WebKit.h>
@@ -18,6 +27,10 @@ static BOOL phantom_view_contains_webview(NSView *view) {
     return NO;
 }
 
+// Returns the NSWindow whose contentView hierarchy hosts the WKWebView, or
+// NULL if none exists yet (e.g. before DomReady). Callers must treat NULL
+// as a transient "window not ready" condition and retry — never substitute
+// another window.
 void *phantom_find_main_window(void) {
     __block void *result = NULL;
     void (^find)(void) = ^{
@@ -27,10 +40,6 @@ void *phantom_find_main_window(void) {
                 result = (__bridge void *)win;
                 return;
             }
-        }
-        // Fallback — first visible window.
-        for (NSWindow *win in [NSApp windows]) {
-            if (win.isVisible) { result = (__bridge void *)win; return; }
         }
     };
     if ([NSThread isMainThread]) {
@@ -43,36 +52,55 @@ void *phantom_find_main_window(void) {
 
 void *phantom_window_content_view(void *window) {
     if (window == NULL) return NULL;
-    NSWindow *win = (__bridge NSWindow *)window;
+    CFRetain(window);
     __block void *result = NULL;
-    void (^get)(void) = ^{ result = (__bridge void *)win.contentView; };
+    void (^get)(void) = ^{
+        NSWindow *win = (__bridge NSWindow *)window;
+        result = (__bridge void *)win.contentView;
+        CFRelease(window);
+    };
     if ([NSThread isMainThread]) get(); else dispatch_sync(dispatch_get_main_queue(), get);
     return result;
 }
 
 double phantom_window_content_height(void *window) {
     if (window == NULL) return 0;
-    NSWindow *win = (__bridge NSWindow *)window;
+    CFRetain(window);
     __block double h = 0;
-    void (^get)(void) = ^{ h = (double)win.contentView.bounds.size.height; };
+    void (^get)(void) = ^{
+        NSWindow *win = (__bridge NSWindow *)window;
+        h = (double)win.contentView.bounds.size.height;
+        CFRelease(window);
+    };
     if ([NSThread isMainThread]) get(); else dispatch_sync(dispatch_get_main_queue(), get);
     return h;
 }
 
-void phantom_add_native_subview(void *parent, void *child) {
-    if (parent == NULL || child == NULL) return;
-    NSView *p = (__bridge NSView *)parent;
-    NSView *c = (__bridge NSView *)child;
+// Attaches child under window's contentView. Takes the WINDOW, not a
+// contentView pointer — the contentView is re-resolved on the main queue
+// inside the block, because a contentView captured at call time can be
+// freed before the async block runs.
+void phantom_add_native_subview(void *window, void *child) {
+    if (window == NULL || child == NULL) return;
+    CFRetain(window);
+    CFRetain(child);
     dispatch_async(dispatch_get_main_queue(), ^{
-        [p addSubview:c];
+        NSWindow *win = (__bridge NSWindow *)window;
+        NSView *content = win.contentView;
+        if (content != nil) {
+            [content addSubview:(__bridge NSView *)child];
+        }
+        CFRelease(window);
+        CFRelease(child);
     });
 }
 
 void phantom_remove_native_subview(void *child) {
     if (child == NULL) return;
-    NSView *c = (__bridge NSView *)child;
+    CFRetain(child);
     dispatch_async(dispatch_get_main_queue(), ^{
-        [c removeFromSuperview];
+        [(__bridge NSView *)child removeFromSuperview];
+        CFRelease(child);
     });
 }
 
@@ -82,9 +110,18 @@ void phantom_remove_native_subview(void *child) {
 // re-acquire focus when the user interacts with the surface region.
 void phantom_make_first_responder(void *window, void *view) {
     if (window == NULL || view == NULL) return;
-    NSWindow *win = (__bridge NSWindow *)window;
-    NSView *v = (__bridge NSView *)view;
+    CFRetain(window);
+    CFRetain(view);
     dispatch_async(dispatch_get_main_queue(), ^{
-        [win makeFirstResponder:v];
+        NSWindow *win = (__bridge NSWindow *)window;
+        NSView *v = (__bridge NSView *)view;
+        // Only focus a view that is actually parented in this window — the
+        // attach block may have bailed (contentView gone) or the view may
+        // have been detached by a racing destroy.
+        if (v.window == win) {
+            [win makeFirstResponder:v];
+        }
+        CFRelease(window);
+        CFRelease(view);
     });
 }

--- a/v2/internal/terminal/ghostty/wails_host.go
+++ b/v2/internal/terminal/ghostty/wails_host.go
@@ -11,9 +11,8 @@ package ghostty
 #cgo darwin LDFLAGS: -framework Cocoa -framework WebKit
 
 extern void *phantom_find_main_window(void);
-extern void *phantom_window_content_view(void *window);
 extern double phantom_window_content_height(void *window);
-extern void phantom_add_native_subview(void *parent, void *child);
+extern void phantom_add_native_subview(void *window, void *child);
 extern void phantom_remove_native_subview(void *child);
 extern void phantom_make_first_responder(void *window, void *view);
 */
@@ -30,23 +29,20 @@ type HostWindow struct {
 }
 
 // FindHostWindow locates the Wails NSWindow by scanning NSApp.windows for
-// the one whose content view contains a WKWebView. Returns an error if no
-// such window exists (e.g. before DomReady).
+// the one whose content view contains a WKWebView. Strict match only — no
+// fallback window. Returns a transient error if no such window exists yet
+// (e.g. before DomReady); callers may retry.
+//
+// CONTRACT (canonical — frontend retry depends on these exact strings):
+//   - transient:  error message CONTAINS "window not ready" → NativeTerminalPane retries (250ms*attempt, max 8)
+//   - permanent:  "native terminal disabled", "libghostty not available" → no retry, error state
+// Do not rename these substrings without updating NativeTerminalPane.tsx and core/bindings/native-terminal.ts.
 func FindHostWindow() (*HostWindow, error) {
 	w := C.phantom_find_main_window()
 	if w == nil {
-		return nil, errors.New("ghostty: no Wails NSWindow found (called before window opened?)")
+		return nil, errors.New("ghostty: window not ready (no Wails NSWindow hosting a WKWebView yet)")
 	}
 	return &HostWindow{window: w}, nil
-}
-
-// ContentView returns the NSWindow's contentView, which is the parent we
-// attach terminal surfaces to.
-func (h *HostWindow) ContentView() unsafe.Pointer {
-	if h == nil || h.window == nil {
-		return nil
-	}
-	return C.phantom_window_content_view(h.window)
 }
 
 // ContentHeight returns the current contentView height in points. Needed
@@ -60,17 +56,16 @@ func (h *HostWindow) ContentHeight() float64 {
 }
 
 // AttachSubview adds an NSView as a subview of the host window's content
-// view. The view is dispatched onto the main queue so this is safe to
-// call from any goroutine.
+// view. The attach is dispatched onto the main queue so this is safe to
+// call from any goroutine. We pass the WINDOW, never a captured
+// contentView — the contentView is re-resolved inside the main-queue
+// block so a contentView freed between call and dispatch is never
+// messaged.
 func (h *HostWindow) AttachSubview(view uintptr) {
 	if h == nil || h.window == nil || view == 0 {
 		return
 	}
-	parent := C.phantom_window_content_view(h.window)
-	if parent == nil {
-		return
-	}
-	C.phantom_add_native_subview(parent, unsafe.Pointer(view))
+	C.phantom_add_native_subview(h.window, unsafe.Pointer(view))
 }
 
 // DetachSubview removes an NSView from its superview.


### PR DESCRIPTION
## Root cause

The native (libghostty) terminal crashed every launch when `PHANTOM_NATIVE_TERMINAL=1` with a saved native pane. `phantom_add_native_subview` captured raw `__bridge` ObjC pointers across a `dispatch_async` hop and messaged them after the view was freed (`EXC_BAD_ACCESS` in `objc_msgSend`). The dangling object came from the "first visible window" fallback in `phantom_find_main_window` grabbing a transient boot window.

**Why nobody saw it:** libghostty's `ghostty_init` installs a sentry-native/breakpad Mach-exception handler that terminates the process before the Go runtime or ReportCrash run — no panic, no `.ips`, no shell signal. Minidump envelopes accumulated invisibly in `~/.local/state/ghostty/crash/` for a month (confirmed by symbolicated minidumps matching repro runs to the minute).

## Changes

- **native_host.m** — CFRetain-at-capture / CFRelease-at-end on every dispatch block (MRC package — captures stay raw `void*`); contentView re-resolved *inside* the attach block; strict WKWebView window match, boot fallback removed
- **wails_host.go** — canonical `window not ready` transient-error contract (documented at `FindHostWindow`); dead `ContentView()` wrapper removed
- **bindings_native_terminal.go** — host window re-resolved per create (no stale cache); destroy-chain serialization invariant documented
- **NativeTerminalPane.tsx** — waits for non-zero container rect; bounded retry on `window not ready` (250ms·attempt, max 8, cleanup-safe)
- **signals.ts** — persisted `native-terminal` panes demote to `terminal` when the flag is off (panes map + layout leaves), so stale workspace state can never wedge a launch; restore awaits `ensureNativeTerminalFlagSynced()` to close the boot flag race
- **ghostty_crash_check.go** (new) — startup WARN when new sentry crash envelopes appeared since last run

## Verification

- `go build -tags ghostty ./...`, `go vet -tags ghostty` (4 pre-existing unsafe.Pointer notes only), `pnpm typecheck`, gofmt — all green
- Gaze quality review: zero P0/P1; 4-perspective pre-ship panel (scope/regression/architecture/skeptic): all pass
- Flag-off default path verified byte-identical (web/PTY terminal untouched)

## Known residual (why the flag stays default-OFF)

Runtime smoke shows the original UAF signature is gone, but a **secondary crash** still reproduces with the flag on: `objc_release` during `_Block_release` dispose on main-queue drain — some `dispatch_async` block still captures a typed ObjC pointer that's dead at block-teardown time. Under investigation (minidump + NSZombie instrumentation); does not affect default users. Crash visibility is now guaranteed by the new envelope scanner.

## Release

Merging triggers release-please; the version tag kicks `release.yml` (build + sign + notarize + publish zip via repo secrets).

Author: Subash Karki